### PR TITLE
modification du texte lien ref:FR:SIRET

### DIFF
--- a/components/ContactAndSocial.tsx
+++ b/components/ContactAndSocial.tsx
@@ -76,7 +76,7 @@ export default function ContactAndSocial({
 				<a
 					href={`https://annuaire-entreprises.data.gouv.fr/etablissement/${siret}`}
 					target="_blank"
-					title="Fiche entreprise sur l'annuaire officiel des entreprises"
+					title="Fiche de l'établissemen sur l'annuaire officiel des entreprises"
 					style={css`
 						display: flex;
 						align-items: center;
@@ -93,7 +93,7 @@ export default function ContactAndSocial({
 						width={14}
 						height={14}
 					/>
-					<span>fiche entreprise</span>
+					<span>fiche de l'établissement</span>
 				</a>
 			)}
 		</div>

--- a/components/ContactAndSocial.tsx
+++ b/components/ContactAndSocial.tsx
@@ -76,7 +76,7 @@ export default function ContactAndSocial({
 				<a
 					href={`https://annuaire-entreprises.data.gouv.fr/etablissement/${siret}`}
 					target="_blank"
-					title="Fiche de l'établissemen sur l'annuaire officiel des entreprises"
+					title="Fiche de l'établissement sur l'annuaire officiel des entreprises"
 					style={css`
 						display: flex;
 						align-items: center;


### PR DESCRIPTION
Je propose de modifier de texte qui correspond au numéro SIRET et pas au numéro SIREN
![image](https://github.com/user-attachments/assets/4a8dcc4f-a8e1-48e4-8191-cffa096b0b10)

SIREN : numéro unique d'identification d'une entreprise
SIRET : numéro unique d'un établissement d'une entreprise
