### PR TITLE
Update osmTagLabels.ts 'Label Accueil Vélo'

### DIFF
--- a/app/osmTagLabels.ts
+++ b/app/osmTagLabels.ts
@@ -37,6 +37,7 @@ export const tagNameCorrespondance = (key: string) => {
 	const found = {
 		alt_name: 'Autre nom',
 		artist_name: "Nom de l'artiste",
+		'award:accueilvelo': "Label Accueil Vélo",
 		books: 'Livres',
 		'brand:website': 'Site de la marque',
 		'building:architecture': 'Style architectural',


### PR DESCRIPTION
Choix du tag sur le forum:

https://forum.openstreetmap.fr/t/network-accueil-velo/27279/15?u=u4y0u

lien wikipédia:
 https://fr.wikipedia.org/wiki/France_V%C3%A9lo_Tourisme#Label_Accueil_V%C3%A9lo

lien du site officiel:
https://www.francevelotourisme.com/accueil-velo

exemple de site sur cartes.app
https://cartes.app/?cat=H%C3%B4tel&allez=H%C3%B4tel+des+C%C3%A8dres%7Cn11660227631%7C1.8961%7C47.9068#15/47.9068/1.8961/15/40