### PR TITLE
Update osmTagLabels.ts Numéro de mobile (phone:mobile)

### DIFF
--- a/app/osmTagLabels.ts
+++ b/app/osmTagLabels.ts
@@ -73,6 +73,7 @@ export const tagNameCorrespondance = (key: string) => {
 	  'payment:debit_cards': 'Paiment par carte de débit',
 		'payment:mastercard': 'Paiement par Mastercard',
 		'payment:visa': 'Paiement par Visa',
+		'phone:mobile': 'N° de mobile',
 		'service:bicycle:cleaning': 'Lavage de vélos',
 		'service:bicycle:diy': "Atelier d'autoréparation de vélos",
 		'service:bicycle:pump': 'Pompe à vélo en libre-service',


### PR DESCRIPTION
Souvent utilisé lorsqu'il y a plusieurs façon de contacter un commerce en combinaison avec phone seul... mais parfois aussi seul comme dans l'exemple ci-dessous.

carte taginfo pour le tag phone:mobile

https://taginfo.openstreetmap.org/keys/phone%3Amobile#map

exemple cates.app
https://cartes.app/?cat=H%C3%B4tel&allez=Au+bord+du+Canal%7Cn12252257806%7C2.8794%7C47.4596#15/47.4596/2.8794/15/40
![image](https://github.com/user-attachments/assets/bd73ac32-0d50-42b5-a35c-fd83080a6f39)

Il serait aussi possible de le mettre sur la même ligne que le phone (ou contact:phone) classique avec ou sans icone particulière....