### PR TITLE
Mise à jour des URL suite au renommage des dépots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 Merci de prendre le temps de contribuer ! 🎉
 
-Voici une [introduction générale](https://github.com/laem/cartes/issues/334) et une liste de questions sur la contribution au projet. 
+Voici une [introduction générale](https://github.com/cartesapp/cartes/issues/334) et une liste de questions sur la contribution au projet.
 
-Aussi, n'oubliez jamais que d'autres sont passés ici avant vous : la section _[issues](https://github.com/laem/cartes/issues)_ contient déjà un tas de problèmes à résoudre et d'informations utiles qui pourraient vous aider à contribuer : utilisez son moteur de recherche.
+Aussi, n'oubliez jamais que d'autres sont passés ici avant vous : la section _[issues](https://github.com/cartesapp/cartes/issues)_ contient déjà un tas de problèmes à résoudre et d'informations utiles qui pourraient vous aider à contribuer : utilisez son moteur de recherche.
 
 ## Comment ajouter une catégorie de recherche de lieux ?
 
-Copiez-collez l'un des blocs dans [categories.yaml](https://github.com/laem/cartes/blob/master/app/categories.yaml) ou [moreCategories.yaml](https://github.com/laem/cartes/blob/master/app/moreCategories.yaml) (les "more" apparaissent seulement au clic sur le gros bouton plus) et changez les attributs.
+Copiez-collez l'un des blocs dans [categories.yaml](https://github.com/cartesapp/cartes/blob/master/app/categories.yaml) ou [moreCategories.yaml](https://github.com/cartesapp/cartes/blob/master/app/moreCategories.yaml) (les "more" apparaissent seulement au clic sur le gros bouton plus) et changez les attributs.
 La partie la plus difficile, c'est l'icône : Maplibre n'accepte pas les icônes SVG, donc nous créons des PNG à la volée et ça implique quelques contraintes. Si vous galérez ou n'êtes pas dev, n'hésitez pas à proposer vos modifications même sans icônes, quelqu'un s'en chargera.
 
 -   le format SVG Inkscape ne marchera pas, il est trop bardé d'attributs inutiles
@@ -18,7 +18,7 @@ La partie la plus difficile, c'est l'icône : Maplibre n'accepte pas les icônes
 
 ### À propos de l'ordre des sous-catégories dans une  
 
-On essaie de classer les catégories par ordre d'utilité pour l'utilisateur. 
+On essaie de classer les catégories par ordre d'utilité pour l'utilisateur.
 
 Par exemple, proposer gymnase avant surf me semble cohérent. Le surf est une activité qui concerne moins de gens et à moindre fréquence.
 
@@ -28,14 +28,14 @@ Après en effet pour ta capture de la catégorie tourisme, c’est moins éviden
 
 L’heuristique n’est pas clairement définie avec une fonction renvoyant un ordre à partir de paramètres statistiques chiffrés, c’est sûr.
 
-À garder en tête également : l'utilité est une notion très vaste, peu définie. Étant donné les fondements du projet Cartes, qui est un **projet politique** d'alternative écologique, il serait tout à fait pertinent de décider de mettre les bornes électriques avant les stations essence, même si ces dernières sont aujourd'hui bien plus utilisées que les premières. 
+À garder en tête également : l'utilité est une notion très vaste, peu définie. Étant donné les fondements du projet Cartes, qui est un **projet politique** d'alternative écologique, il serait tout à fait pertinent de décider de mettre les bornes électriques avant les stations essence, même si ces dernières sont aujourd'hui bien plus utilisées que les premières.
 
 > Cela dit, il sera possible dans le futur de recueillir des chiffres sur l’usage, pour donner une des dimensions du classement. Mais encore une fois, ça me semble moins important que de bosser la découverte de ces catégories via la recherche. Le moteur de recherche est l’interface de base du grand public, avant le catalogue de catégories.
 
 
 ## Comment ajouter un réseau de transport en commun ?
 
-Direction l'[autre dépot](https://github.com/laem/gtfs), côté serveur.
+Direction l'[autre dépot](https://github.com/cartesapp/serveur), côté serveur.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Découvrez [nos motivations](https://cartes.app/blog/un-beau-voyage) et les dern
 
 ## Comment contribuer ?
 
-C'est par ici : [guide de contribution](https://github.com/laem/cartes/blob/master/CONTRIBUTING.md) !
+C'est par ici : [guide de contribution](https://github.com/cartesapp/cartes/blob/master/CONTRIBUTING.md) !
 Vous pouvez aussi poser des questions sur la section issues ou sur le [canal matrix](https://matrix.to/#/#cartes:matrix.org) pour les questions plus informelles.
 
 ## Et techniquement

--- a/app/blog/Contribution.tsx
+++ b/app/blog/Contribution.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 export default function Contribution({ slug }) {
 	return (
 		<Link
-			href={`https://github.com/laem/cartes/edit/master/articles/${slug}.mdx`}
+			href={`https://github.com/cartesapp/cartes/edit/master/articles/${slug}.mdx`}
 			style={css`
 				display: block;
 				margin: 0 0 0 auto;

--- a/app/blog/utils.ts
+++ b/app/blog/utils.ts
@@ -5,7 +5,7 @@ export const dateCool = (date) =>
 		day: 'numeric',
 	})
 
-const repo = 'laem/cartes'
+const repo = 'cartesapp/cartes'
 
 export const getLastEdit = async (name) => {
 	try {

--- a/app/explanations.mdx
+++ b/app/explanations.mdx
@@ -14,6 +14,6 @@ Pour l'instant, nos efforts sont concentrés sur la France hexagonale. L'aventur
 
 Découvrez 📜 [la raison d'être du projet](/blog/un-beau-voyage).
 
-Ce service est gratuit, entièrement [libre](https://github.com/laem/cartes), et sans collecte de données. [À propos](/a-propos).
+Ce service est gratuit, entièrement [libre](https://github.com/cartesapp/cartes), et sans collecte de données. [À propos](/a-propos).
 
 Il est construit sur la carte collaborative <OsmAttribution/> et nombre d'autres [projets](/presentation/dependances).

--- a/app/styles/france.ts
+++ b/app/styles/france.ts
@@ -26,7 +26,7 @@ export default function franceStyle(transportMode, noVariableTiles = false) {
 		name: transportMode ? 'Transports' : 'France',
 		sources: {
 			// We're not really using openmaptiles anymore, but a modified version of
-			// it, see cartesapp/gtfs/tiles.ts
+			// it, see cartesapp/serveur/tiles.ts
 			openmaptiles: {
 				url: openmaptilesUrl,
 				//url: 'pmtiles://https://panoramax.openstreetmap.fr/pmtiles/planet.pmtiles',
@@ -119,7 +119,7 @@ const lightenLayers = (layers) =>
 		}
 	})
 
-// See laem/gtfs's process-openmaptiles.lua
+// See cartesapp/serveur's process-openmaptiles.lua
 export const nameExpression = [
 	['get', 'name:fr'], // cartes.app est une application française
 	['get', 'name:latin'], // keep compatibility with Panoramax's planet.pmtiles that cover other tiles than the 4 mega tiles surrounding the hexagone

--- a/app/transport-en-commun/page.tsx
+++ b/app/transport-en-commun/page.tsx
@@ -102,7 +102,7 @@ export default async function () {
 				<p>
 					Dans la liste ci-dessous, un lien signifie que le réseau est intégré.
 					Le vôtre n'y est pas ?{' '}
-					<a href="https://github.com/laem/gtfs?tab=readme-ov-file#couverture">
+					<a href="https://github.com/cartesapp/serveur?tab=readme-ov-file#couverture">
 						Venez aider !
 					</a>
 				</p>

--- a/components/dependencies.yaml
+++ b/components/dependencies.yaml
@@ -45,4 +45,4 @@
   url: photon.komoot.io
 - img: /three-dots.svg
   text: Le vôtre ?
-  url: github.com/laem/cartes/issues
+  url: github.com/cartesapp/cartes/issues

--- a/components/transit/modes.ts
+++ b/components/transit/modes.ts
@@ -33,7 +33,7 @@ export const stepModeParamsToMotis = (stepModeParams, distance) => {
 	// This is the state of the art of our comprehension of how to use Motis to
 	// produce useful intermodal results in France, letting the user find the
 	// closest train station for more long range requests
-	// See https://github.com/laem/cartes/issues/416
+	// See https://github.com/cartesapp/cartes/issues/416
 	//
 	// Here we set a threshold in km (50) for either not asking a trip starting with a bike
 	// segment because we expect the user will use local transit, or ask it with a

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"author": "Maël THOMAS-QUILLÉVÉRÉ <laem@kont.me>",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/laem/cartes.git"
+		"url": "https://github.com/cartesapp/cartes.git"
 	},
 	"engines": {
 		"node": ">=18"


### PR DESCRIPTION
Cette PR met à jour les urls vers les dépôt malgré le fait que Github sait gérer la redirection