### PR TITLE
Possibilité de rechercher sur cartes.app via un SmartKeyword

### DIFF
--- a/app/PlaceSearch/_components/SearchBar.tsx
+++ b/app/PlaceSearch/_components/SearchBar.tsx
@@ -24,15 +24,16 @@ export default ({
 }: IProps) => {
 	return (
 		<InputStyle $stateBeingSearched={getHasStepBeingSearched(state)}>
-			<input
-				type="text"
-				value={value || ''}
-				onBlur={() => setIsMyInputFocused(false)}
-				onFocus={() => setIsMyInputFocused(true)}
-				autoFocus={autofocus}
-				onClick={(e) => {
-					setSnap(0, 'PlaceSearch')
-					/*
+			<form action="/" method="GET" role="search">
+				<input
+					type="text"
+					value={value || ''}
+					onBlur={() => setIsMyInputFocused(false)}
+					onFocus={() => setIsMyInputFocused(true)}
+					autoFocus={autofocus}
+					onClick={(e) => {
+						setSnap(0, 'PlaceSearch')
+						/*
 				// Old comment :
 				// --------------
 				// Combining two calls hits the sweet spot between chrome and
@@ -54,10 +55,11 @@ export default ({
 					e.target.focus()
 				}, 600)
 				*/
-				}}
-				placeholder={placeholder || 'Saint-Malo, Nancy, Café du Port...'}
-				onChange={({ target: { value } }) => onDestinationChange(value)}
-			/>
+					}}
+					placeholder={placeholder || 'Saint-Malo, Nancy, Café du Port...'}
+					onChange={({ target: { value } }) => onDestinationChange(value)}
+				/>
+			</form>
 			{value && (
 				<button
 					onClick={() => onDestinationChange(null)}

--- a/app/PlaceSearch/_components/SearchBar.tsx
+++ b/app/PlaceSearch/_components/SearchBar.tsx
@@ -24,7 +24,14 @@ export default ({
 }: IProps) => {
 	return (
 		<InputStyle $stateBeingSearched={getHasStepBeingSearched(state)}>
-			<form action="/" method="GET" role="search">
+			<form
+				action="/"
+				method="GET"
+				role="search"
+				onKeyDown={(e) => {
+					e.key === 'Enter' && e.preventDefault()
+				}}
+			>
 				<input
 					type="text"
 					value={value || ''}


### PR DESCRIPTION
En prenant exemple sur le HTML du champ de recherche de fnac.com, j'ai ajouté le minimum de code nécessaire pour faire apparaître "Ajouter un mot clé pour cette recherche…" dans le menu lorsqu'on fait clic droit sur le champ de recherche :

- un element `<form>` avec
  - le chemin cible de l'URL de recherche
  - la méthode HTTP ("GET")
  - le rôle du formulaire HTML ("search")
- ajouter un attribut `name` à l'input de recherche avec le même nom que le paramètre utilisé par la recherche par URL (voir https://github.com/cartesapp/cartes/issues/159#issuecomment-1994941346)

Il ne semble pas exister de spec standard pour l'implémentation de cette fonctionnalité.

Voir aussi [la doc utilisateur]( https://support.mozilla.org/fr/kb/comment-rechercher-site-barre-adresse) de Mozilla sur comment utiliser les Smart Keywords côté utilisateur final.