### PR TITLE
Add a name to the search bar's input so that a keyword can be added in Firefox

### DIFF
--- a/app/PlaceSearch/_components/SearchBar.tsx
+++ b/app/PlaceSearch/_components/SearchBar.tsx
@@ -34,6 +34,7 @@ export default ({
 			>
 				<input
 					type="text"
+					name="q"
 					value={value || ''}
 					onBlur={() => setIsMyInputFocused(false)}
 					onFocus={() => setIsMyInputFocused(true)}


### PR DESCRIPTION
This is coming from the mastodon thread https://floss.social/@pieq/113788086581486239.

Please tell me if anything else needs to be done to get this landed :-)

Thanks!