### PR TITLE
make unnamed POIs visible and clickable

### DIFF
--- a/app/effects/useMapClick.ts
+++ b/app/effects/useMapClick.ts
@@ -7,6 +7,7 @@ import { replaceArrayIndex } from '@/components/utils/utils'
 import { useEffect } from 'react'
 import { nameExpression } from '../styles/france'
 import handleCirconscriptionsLegislativesClick from './handleCirconscriptionsLegislativesClick'
+import { buildOsmFeatureCategory } from '@/components/osm/buildDescription'
 
 export default function useMapClick(
 	map,
@@ -159,11 +160,12 @@ export default function useMapClick(
 					'merge'
 				)
 
+				const osmFeatureCategory = buildOsmFeatureCategory(element)
 				// We store longitude and latitude in order to, in some cases, avoid a
 				// subsequent fetch request on link share
 				setSearchParams({
 					allez: buildAllezPart(
-						element.tags?.name || 'sans nom',
+						element.tags?.name || osmFeatureCategory || 'sans nom',
 						encodePlace(realFeatureType, id),
 						longitude,
 						latitude

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 // Server components here
 import buildPlaceJsonLd from '@/buildPlaceJsonLd'
+import { buildPlaceMap } from '@/components/buildPlaceMap'
 import fetchOgImage from '@/components/fetchOgImage'
 import buildDescription from '@/components/osm/buildDescription'
 import fetchAgency, {
@@ -14,9 +15,8 @@ import { buildAllezPartFromOsmFeature } from './SetDestination'
 import { fetchSimilarNodes } from './effects/fetchOverpassRequest'
 import getName from './osm/getName'
 import getUrl from './osm/getUrl'
-import { getFetchUrlBase, gtfsServerUrl } from './serverUrls'
+import { getFetchUrlBase } from './serverUrls'
 import { stepOsmRequest } from './stepOsmRequest'
-import { buildPlaceMap } from '@/components/buildPlaceMap'
 
 export async function generateMetadata(
 	props: Props,

--- a/app/styles/france.ts
+++ b/app/styles/france.ts
@@ -2903,7 +2903,6 @@ On n'est pas à l'abri d'effets secondaires ici.
 		metadata: {},
 		filter: [
 			'all',
-			hasNameExpression,
 			['!in', 'class', 'hospital', 'parking', 'railway', 'park'],
 		],
 	},

--- a/app/styles/voyage.ts
+++ b/app/styles/voyage.ts
@@ -2602,7 +2602,6 @@ export default function voyageStyle(
 				metadata: {},
 				filter: [
 					'all',
-					['has', name],
 					['!in', 'class', 'hospital', 'parking', 'railway'],
 				],
 			},

--- a/components/osm/buildDescription.ts
+++ b/components/osm/buildDescription.ts
@@ -8,14 +8,22 @@ export default function buildOsmFeatureDescription(osmFeature) {
 
 	const address = tags && buildAddress(tags)
 
-	const [, soloTags] = processTags(tags) // processTags should get filteredRest as input, but see OsmFeature.tsx's TODO
+	const osmFeatureCategory = buildOsmFeatureCategory(osmFeature)
 
-	const mainTags = soloTags.map(([raw, tag]) => tag)
 	return [
-		mainTags.join(' '),
+		osmFeatureCategory,
 		descriptionTag,
 		...(address ? [". À l'adresse " + address] : []),
 	]
 		.filter(Boolean)
 		.join(' - ')
+}
+
+export const buildOsmFeatureCategory = (osmFeature) => {
+	if (!osmFeature.tags) return null
+	const [, soloTags] = processTags(osmFeature.tags) // processTags should get filteredRest as input, but see OsmFeature.tsx's TODO
+
+	if (!soloTags?.length) return null
+	const mainTags = soloTags.map(([raw, tag]) => tag)
+	return mainTags.join(' ')
 }


### PR DESCRIPTION
resolves #784

Bon je pensais pas que ça serait si simple, j'ai juste supprimé dans les styles de fond de carte le filtre qui masquait les POIs sans nom. Mais j'imagine que ce filtre n'était pas là pour rien, donc j'espère que ça ne provoque pas de régression ailleurs ?
Quand on clique sur un tel POI sans nom, l'url contient `?allez=sans+nom`, est-ce gênant ?
Pour le reste, ça marche bien, ça affiche bien les infos sur le lieu.

![image](https://github.com/user-attachments/assets/7fe1cb80-228a-4d86-a489-62477bdb8cee)


