### PR TITLE
documentation des scripts de chargement des icones dans la carte

### DIFF
--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -138,9 +138,9 @@ const Category = styled.li`
 			: ''}
 `
 const MapIcon = ({ category, color, bulkImages }) => {
-	const src = bulkImages['cartesapp-' + category['icon']]
+	const src = bulkImages[category['icon alias'] || category['icon']]
 
-	const alt = 'Icône de la catégorie' + (category.title || category.name)
+	const alt = 'Icône de la catégorie ' + (category.title || category.name)
 
 	if (src) return <MapIconImage src={src} alt={alt} width="10" height="10" />
 }

--- a/app/categories.yaml
+++ b/app/categories.yaml
@@ -20,7 +20,7 @@
     - '[amenity=restaurant]'
     - '[vending=pizza]'
   icon: restaurant
-  category: Alimentation
+  category: Restaurants
 - name: cafe
   title: Café, bar et pub
   dictionary:
@@ -60,7 +60,7 @@
     - '[drinking_water=yes]'
   icon: water
   open by default: true
-  category: Divers
+  category: Bars et boisson
 - name: toilettes
   dictionary:
     - WC

--- a/app/effects/useDrawQuickSearchFeatures.ts
+++ b/app/effects/useDrawQuickSearchFeatures.ts
@@ -29,130 +29,33 @@ export default function useDrawQuickSearchFeatures(
 		if (!features?.length) return
 
 		// on reconstruit le nom de l'icone : l'alias si précisé, sinon le nom du svg
-		const iconName = category['icon alias'] || category.icon
+		const imageFilename = category.icon
+		const imageFinalFilename = category['icon alias']
+		const iconName = imageFinalFilename || imageFilename
 		// et le nom avec lequel l'image a été ajoutée dans maplibre
 		const mapImageName = 'cartesapp-' + iconName // avoid collisions
 
-		console.log('useDrawQuickSearchFeatures add source ', baseId + 'points')
+		buildSvgImage(
+			imageFilename,
+			imageFinalFilename,
+			(img) => {
+				// TODO this should be useless now that we've added all the icons in
+				// useAddMap, since they are also used to replace the sprites for tile
+				// icons
+				const mapImage = map.getImage(mapImageName)
+				if (!mapImage) map.addImage(mapImageName, img)
 
-		// on prépare les sources qui vont contenir les ways et les points renvoyés par overpass
-		const geojsonPlaceholder = { type: 'FeatureCollection', features: [] }
-		map.addSource(baseId + 'points', {
-			type: 'geojson',
-			data: geojsonPlaceholder,
-		})
-		map.addSource(baseId + 'ways', {
-			type: 'geojson',
-			data: geojsonPlaceholder,
-		})
-		setSources({
-			points: map.getSource(baseId + 'points'),
-			ways: map.getSource(baseId + 'ways'),
-		})
-
-		// on ajoute les layers qui vont permettre de dessiner les données
-		// l'intérieur des ways
-		map.addLayer({
-			id: baseId + 'ways',
-			type: 'fill',
-			source: baseId + 'ways',
-			layout: {},
-			paint: {
-				'fill-color': colors['lightestColor'],
-				'fill-opacity': 0.3,
+				draw(
+					map,
+					baseId,
+					setSearchParams,
+					setSources,
+					mapImageName,
+					setOsmFeature
+				)
 			},
-		})
-		// la bordure des ways
-		map.addLayer({
-			id: baseId + 'ways-outlines',
-			type: 'line',
-			source: baseId + 'ways',
-			layout: {},
-			paint: {
-				'line-color': colors['color'],
-				'line-width': 2,
-			},
-		})
-		// les points
-		map.addLayer({
-			id: baseId + 'points',
-			type: 'symbol',
-			source: baseId + 'points',
-			layout: {
-				'icon-image': mapImageName, // en utilisant l'image déjà chargée pour le fond de carte
-				'icon-size': 1,
-				'text-field': ['get', 'name'],
-				'text-offset': [0, 1.25],
-				'text-anchor': 'top',
-				'text-font': ['RobotoBold-NotoSansBold'],
-				'text-size': 15,
-			},
-			paint: {
-				'text-color': '#503f38',
-				'text-halo-blur': 0.5,
-				'text-halo-color': 'white',
-				'text-halo-width': 1,
-				'icon-halo-color': '#503f38',
-				'icon-halo-width': 100,
-				'icon-halo-blur': 0.5,
-			},
-		})
-		// les petits cercles pour indiquer si le lieu est ouvert
-		map.addLayer({
-			id: baseId + 'points-is-open',
-			type: 'circle',
-			source: baseId + 'points',
-			paint: {
-				'circle-radius': 4,
-				'circle-color': ['get', 'isOpenColor'],
-				'circle-stroke-color': colors['color'],
-				'circle-stroke-width': 1.5,
-				'circle-translate': [12, -12],
-			},
-			filter: ['!=', 'isOpenColor', false],
-		})
-
-		// gestion des actions en cas de de clic sur un POI
-		map.on('click', baseId + 'points', async (e) => {
-			// on charge les infos sur le POI
-			const feature = e.features[0]
-			const { lng: longitude, lat: latitude } = e.lngLat
-			const properties = feature.properties,
-				tagsRaw = properties.tags
-			console.log('quickSearchOSMfeatureClick', feature)
-			const tags =
-				typeof tagsRaw === 'string' ? JSON.parse(tagsRaw) : tagsRaw
-
-			// on change l'URL affichée dans le navigateur
-			setTimeout(
-				() =>
-					setSearchParams({
-						allez: buildAllezPart(
-							tags?.name || 'sans nom',
-							encodePlace(properties.featureType, properties.id),
-							longitude,
-							latitude
-						),
-					}),
-				200
-			)
-
-			// on charge les données et on les affiche ?
-			const osmFeature = { ...properties, tags }
-			console.log(
-				'will set OSMfeature after quickSearch marker click, ',
-				osmFeature
-			)
-			setOsmFeature(osmFeature)
-		})
-
-		// change pointer when entering or leaving a POI
-		map.on('mouseenter', baseId + 'points', () => {
-			map.getCanvas().style.cursor = 'pointer'
-		})
-		map.on('mouseleave', baseId + 'points', () => {
-			map.getCanvas().style.cursor = ''
-		})
+			backgroundColor
+		)
 
 		// for cleaning ?
 		const cleanup = () => {
@@ -258,4 +161,133 @@ export default function useDrawQuickSearchFeatures(
 		sources.ways.setData(waysData)
 		sources.points.setData(pointsData)
 	}, [category, features, showOpenOnly, safeStyleKey, sources])
+}
+
+const draw = (
+	map,
+	baseId,
+	setSearchParams,
+	setSources,
+	mapImageName,
+	setOsmFeature
+) => {
+	console.log('useDrawQuickSearchFeatures add source ', baseId + 'points')
+
+	// on prépare les sources qui vont contenir les ways et les points renvoyés par overpass
+	const geojsonPlaceholder = { type: 'FeatureCollection', features: [] }
+	map.addSource(baseId + 'points', {
+		type: 'geojson',
+		data: geojsonPlaceholder,
+	})
+	map.addSource(baseId + 'ways', {
+		type: 'geojson',
+		data: geojsonPlaceholder,
+	})
+	setSources({
+		points: map.getSource(baseId + 'points'),
+		ways: map.getSource(baseId + 'ways'),
+	})
+
+	// on ajoute les layers qui vont permettre de dessiner les données
+	// l'intérieur des ways
+	map.addLayer({
+		id: baseId + 'ways',
+		type: 'fill',
+		source: baseId + 'ways',
+		layout: {},
+		paint: {
+			'fill-color': colors['lightestColor'],
+			'fill-opacity': 0.3,
+		},
+	})
+	// la bordure des ways
+	map.addLayer({
+		id: baseId + 'ways-outlines',
+		type: 'line',
+		source: baseId + 'ways',
+		layout: {},
+		paint: {
+			'line-color': colors['color'],
+			'line-width': 2,
+		},
+	})
+	// les points
+	map.addLayer({
+		id: baseId + 'points',
+		type: 'symbol',
+		source: baseId + 'points',
+		layout: {
+			'icon-image': mapImageName, // en utilisant l'image déjà chargée pour le fond de carte
+			'icon-size': 1,
+			'text-field': ['get', 'name'],
+			'text-offset': [0, 1.25],
+			'text-anchor': 'top',
+			'text-font': ['RobotoBold-NotoSansBold'],
+			'text-size': 15,
+		},
+		paint: {
+			'text-color': '#503f38',
+			'text-halo-blur': 0.5,
+			'text-halo-color': 'white',
+			'text-halo-width': 1,
+			'icon-halo-color': '#503f38',
+			'icon-halo-width': 100,
+			'icon-halo-blur': 0.5,
+		},
+	})
+	// les petits cercles pour indiquer si le lieu est ouvert
+	map.addLayer({
+		id: baseId + 'points-is-open',
+		type: 'circle',
+		source: baseId + 'points',
+		paint: {
+			'circle-radius': 4,
+			'circle-color': ['get', 'isOpenColor'],
+			'circle-stroke-color': colors['color'],
+			'circle-stroke-width': 1.5,
+			'circle-translate': [12, -12],
+		},
+		filter: ['!=', 'isOpenColor', false],
+	})
+
+	// gestion des actions en cas de de clic sur un POI
+	map.on('click', baseId + 'points', async (e) => {
+		// on charge les infos sur le POI
+		const feature = e.features[0]
+		const { lng: longitude, lat: latitude } = e.lngLat
+		const properties = feature.properties,
+			tagsRaw = properties.tags
+		console.log('quickSearchOSMfeatureClick', feature)
+		const tags = typeof tagsRaw === 'string' ? JSON.parse(tagsRaw) : tagsRaw
+
+		// on change l'URL affichée dans le navigateur
+		setTimeout(
+			() =>
+				setSearchParams({
+					allez: buildAllezPart(
+						tags?.name || 'sans nom',
+						encodePlace(properties.featureType, properties.id),
+						longitude,
+						latitude
+					),
+				}),
+			200
+		)
+
+		// on charge les données et on les affiche ?
+		const osmFeature = { ...properties, tags }
+		console.log(
+			'will set OSMfeature after quickSearch marker click, ',
+			osmFeature
+		)
+		setOsmFeature(osmFeature)
+	})
+
+	// change pointer when entering or leaving a POI
+	map.on('mouseenter', baseId + 'points', () => {
+		map.getCanvas().style.cursor = 'pointer'
+	})
+	map.on('mouseleave', baseId + 'points', () => {
+		map.getCanvas().style.cursor = ''
+	})
 }

--- a/app/effects/useDrawQuickSearchFeatures.ts
+++ b/app/effects/useDrawQuickSearchFeatures.ts
@@ -22,7 +22,6 @@ export default function useDrawQuickSearchFeatures(
 
 	const [sources, setSources] = useState(null)
 
-	console.log('cyan debug drawquick', backgroundColor)
 	useEffect(() => {
 		// on annule si la carte ou les features sont manquants
 		if (!map) return
@@ -35,27 +34,38 @@ export default function useDrawQuickSearchFeatures(
 		// et le nom avec lequel l'image a été ajoutée dans maplibre
 		const mapImageName = 'cartesapp-' + iconName // avoid collisions
 
-		buildSvgImage(
-			imageFilename,
-			imageFinalFilename,
-			(img) => {
-				// TODO this should be useless now that we've added all the icons in
-				// useAddMap, since they are also used to replace the sprites for tile
-				// icons
-				const mapImage = map.getImage(mapImageName)
-				if (!mapImage) map.addImage(mapImageName, img)
+		if (safeStyleKey != null && safeStyleKey === 'france')
+			draw(
+				map,
+				baseId,
+				setSearchParams,
+				setSources,
+				mapImageName,
+				setOsmFeature
+			)
+		else {
+			buildSvgImage(
+				imageFilename,
+				imageFinalFilename,
+				(img) => {
+					// TODO this should be useless now that we've added all the icons in
+					// useAddMap, since they are also used to replace the sprites for tile
+					// icons
+					const mapImage = map.getImage(mapImageName)
+					if (!mapImage) map.addImage(mapImageName, img)
 
-				draw(
-					map,
-					baseId,
-					setSearchParams,
-					setSources,
-					mapImageName,
-					setOsmFeature
-				)
-			},
-			backgroundColor
-		)
+					draw(
+						map,
+						baseId,
+						setSearchParams,
+						setSources,
+						mapImageName,
+						setOsmFeature
+					)
+				},
+				backgroundColor
+			)
+		}
 
 		// for cleaning ?
 		const cleanup = () => {

--- a/app/effects/useMapIcons.ts
+++ b/app/effects/useMapIcons.ts
@@ -60,18 +60,17 @@ export default function useMapIcons(map, styleUrl) {
 
 			console.log('imageRedirects', imageRedirects)
 
-			//const count = bulkIcons.length
-			//let iterator = 0
-
 			// on parcourt les 2 listes( /svgo/bulk + les redirections) pour ajouter chaque image à la carte
 			;[...imageRedirects, ...bulkIcons].map(([iconName, imgSrc]) => {
 
+				// on définit le nom d'icone que la carte verra
+				const mapImageName = 'cartesapp-' + iconName // avoid collisions
 				// on vérifie que la carte n'a pas déjà une image du même nom
-				const hasMapImage = map.hasImage(iconName)
+				const hasMapImage = map.hasImage(mapImageName)
 				if (hasMapImage) {
-					console.log('map has already image: ', iconName)
+					console.log('map has already image: ', mapImageName)
 				} else {
-					console.log('add image to the map: ', iconName)
+					console.log('add image to the map: ', mapImageName)
 					// on choisit la taille de l'image
 					const isSmall = Object.keys(imageRedirectsRaw['small']).find(
 						(k) => k === iconName
@@ -84,7 +83,7 @@ export default function useMapIcons(map, styleUrl) {
 
 					// une fois l'image chargée, on l'ajoute à la carte :
 					img.onload = () => {
-						map.addImage('cartesapp-' + iconName, img) // add prefix to iconName to avoid collisions
+						map.addImage(mapImageName, img) // add prefix to iconName to avoid collisions
 					}
 				}
 			})

--- a/app/effects/useMapIcons.ts
+++ b/app/effects/useMapIcons.ts
@@ -3,12 +3,15 @@ import { useEffect } from 'react'
 //chargement du yaml contenant la gestion des redirections
 import imageRedirectsRaw from '@/app/imageRedirects.yaml'
 
+export const shouldNotAddIconsToMapStyle = (styleUrl) =>
+	!styleUrl || typeof styleUrl !== 'object' || styleUrl.name !== 'France'
+
 export default function useMapIcons(map, styleUrl) {
 	useEffect(() => {
 		// on annule si la carte n'est pas chargée, ou si autre style que le style france.
 		if (!map) return
-		if (!styleUrl || typeof styleUrl !== 'object' || styleUrl.name !== 'France')
-			return
+		if (shouldNotAddIconsToMapStyle(styleUrl)) return
+
 		console.log('cyan will add map icons')
 
 		// surveillances des icones que la carte voudrait afficher mais qui manquent
@@ -38,14 +41,14 @@ export default function useMapIcons(map, styleUrl) {
 					// si l'icone n'est pas spécifiée, on prévient et on passe à la suivante
 					if (!to) {
 						console.log(
-							'tile (sub)class value ' + from + ' listed but no cartesapp icon correspondance'
+							'tile (sub)class value ' +
+								from +
+								' listed but no cartesapp icon correspondance'
 						)
 						return
 					}
 					// on cherche dans le json le nom d'icone qui correspond à la redirection
-					const found = bulkIcons.find(
-						([iconName, imgSrc]) => iconName === to
-					)
+					const found = bulkIcons.find(([iconName, imgSrc]) => iconName === to)
 
 					// si l'icone n'existe pas dans le json /svgo/bulk, on alerte
 					if (!found || !Array.isArray(found))
@@ -62,7 +65,6 @@ export default function useMapIcons(map, styleUrl) {
 
 			// on parcourt les 2 listes( /svgo/bulk + les redirections) pour ajouter chaque image à la carte
 			;[...imageRedirects, ...bulkIcons].map(([iconName, imgSrc]) => {
-
 				// on définit le nom d'icone que la carte verra
 				const mapImageName = 'cartesapp-' + iconName // avoid collisions
 				// on vérifie que la carte n'a pas déjà une image du même nom

--- a/app/effects/useMapIcons.ts
+++ b/app/effects/useMapIcons.ts
@@ -1,13 +1,17 @@
 import { useEffect } from 'react'
 
+//chargement du yaml contenant la gestion des redirections
 import imageRedirectsRaw from '@/app/imageRedirects.yaml'
 
 export default function useMapIcons(map, styleUrl) {
 	useEffect(() => {
+		// on annule si la carte n'est pas chargée, ou si autre style que le style france.
 		if (!map) return
 		if (!styleUrl || typeof styleUrl !== 'object' || styleUrl.name !== 'France')
 			return
 		console.log('cyan will add map icons')
+
+		// surveillances des icones que la carte voudrait afficher mais qui manquent
 		const onImageMissing = (e) => {
 			const id = e.id // id of the missing image
 			console.log('imagemissing', id)
@@ -22,75 +26,65 @@ export default function useMapIcons(map, styleUrl) {
 
 		window.map = map
 		const doFetch = async () => {
+			// on charge le json contenant la liste de toutes les icones à ajouter
 			const request = await fetch('/svgo/bulk')
-			const nameSrcMap = await request.json()
-			console.log('nameSrcMap', nameSrcMap)
-			const imageRedirects = Object.entries(imageRedirectsRaw)
-				.filter(([k]) => !['not in categories', 'small'].includes(k))
+			const bulkIcons = await request.json()
+			console.log('bulkIcons', bulkIcons)
+			// on parcourt la liste des redirections à gérer
+			// (uniquement celle du cas 1 vers les icones définies dans les catégories
+			// car les cas 2 et 3 sont déjà inclus dans /svgo/bulk )
+			const imageRedirects = Object.entries(imageRedirectsRaw['in categories'])
 				.map(([from, to]) => {
+					// si l'icone n'est pas spécifiée, on prévient et on passe à la suivante
 					if (!to) {
 						console.log(
-							'imagemissing listed but no cartesapp icon correspondance'
+							'tile (sub)class value ' + from + ' listed but no cartesapp icon correspondance'
 						)
 						return
 					}
-					const found = nameSrcMap.find(
-						([name, src]) => name.split('cartesapp-')[1] === to
+					// on cherche dans le json le nom d'icone qui correspond à la redirection
+					const found = bulkIcons.find(
+						([iconName, imgSrc]) => iconName === to
 					)
 
+					// si l'icone n'existe pas dans le json /svgo/bulk, on alerte
 					if (!found || !Array.isArray(found))
 						console.error(
 							`Problème avec la redirection d'icône ${found} ${from} ${to}`
 						)
 
-					const [name, src] = found
-					return ['cartesapp-' + from, src]
+					const [iconName, imgSrc] = found // on remplace l'item par vrai/faux
+					return [from, imgSrc] // on renvoit l'icone avec le nouveau nom
 				})
-				.filter(Boolean)
+				.filter(Boolean) // on filtre pour ne garder que les icones trouvées
 
-			console.log('missingRedirects', imageRedirects)
+			console.log('imageRedirects', imageRedirects)
 
-			const count = nameSrcMap.length
-			let iterator = 0
+			//const count = bulkIcons.length
+			//let iterator = 0
 
-			;[...imageRedirects, ...nameSrcMap].map(([imageFinalName, src]) => {
-				//build svg image and add to map
-				const isSmall = Object.keys(imageRedirectsRaw['small']).find(
-					(k) => k === imageFinalName.replace('cartesapp-', '')
-				)
-				const size = isSmall ? 14 : 30
-				const img = new Image(size, size) // bonne taille pour être cohérent avec les sprites d'origine
+			// on parcourt les 2 listes( /svgo/bulk + les redirections) pour ajouter chaque image à la carte
+			;[...imageRedirects, ...bulkIcons].map(([iconName, imgSrc]) => {
 
-				img.src = src
+				// on vérifie que la carte n'a pas déjà une image du même nom
+				const hasMapImage = map.hasImage(iconName)
+				if (hasMapImage) {
+					console.log('map has already image: ', iconName)
+				} else {
+					console.log('add image to the map: ', iconName)
+					// on choisit la taille de l'image
+					const isSmall = Object.keys(imageRedirectsRaw['small']).find(
+						(k) => k === iconName
+					)
+					const size = isSmall ? 14 : 30
 
-				img.onload = () => {
-					const hasMapImage = map.hasImage(imageFinalName)
-					console.log('addimage ', imageFinalName)
-					if (!hasMapImage) {
-						console.log('addimage ', imageFinalName)
-						map.addImage(imageFinalName, img)
-						iterator += 1
-						console.log('iterator', iterator, count)
-						if (iterator === count) {
-							console.log('PLOP')
-							//map.triggerRepaint() //not working
-							return
-							// not working either
-							map.setLayoutProperty('Other POI', 'icon-image', [
-								'coalesce',
-								['image', ['concat', 'cartesapp-', ['get', 'subclass']]],
-								['image', ['concat', 'cartesapp-', ['get', 'class']]],
-								// sinon on essaye les sprites standards du style d'origine
-								['image', ['get', 'subclass']],
-								['image', ['get', 'class']],
-								['image', 'dot'],
-							])
+					// on crée l'image
+					const img = new Image(size, size)
+					img.src = imgSrc
 
-							//map.setStyle(styleUrl) //triggers an error
-						}
-						//map.updateImage(imageFinalName, img) // this does not suffice. It's the style that must be reloaded...
-					} else {
-						iterator += 1
+					// une fois l'image chargée, on l'ajoute à la carte :
+					img.onload = () => {
+						map.addImage('cartesapp-' + iconName, img) // add prefix to iconName to avoid collisions
 					}
 				}
 			})

--- a/app/imageRedirects.yaml
+++ b/app/imageRedirects.yaml
@@ -1,39 +1,47 @@
-# OMT MapLibre Tile Data image name -> cartesapp category icon names
-town_hall: classical-building
-bar: beer
-garden: tree
-park: tree
-books: book
-bicycle_rental: bicycle
-atm: bank
-biergarten: beer
-bus_station: bus
-clinic: hospital
-courthouse: classical-building
-dentist: tooth
-drinking_water: water
-ferry_terminal: ferry
-fire_station: fire
-food_court: restaurant
-grave_yard: cemetery
-camp_site: camping
-wine: grapes
-swimming: swimming_outdoor
-swimming_pool: swimming_outdoor
-#place_of_worship:
+# LIST OF ICON REDIRECTIONS
+# List of all the redirections to be applied from the class/subclass values in the tile schema (OpenMalTiles + complements) to the icon in cartes.app
+
+# expected values :
+# tile schema class/subclass name -> cartesapp icon name (case 1) or svg name (cases 2 and 3) (can be ommited if identical)
+
+# part 1/3 : using cartes.app icons already described in moreCategories.yaml (so already included in /svgo/bulk)
+in categories:
+  town_hall: classical-building
+  bar: beer
+  garden: tree
+  park: tree
+  books: book
+  bicycle_rental: bicycle
+  atm: bank
+  biergarten: beer
+  bus_station: bus
+  clinic: hospital
+  courthouse: classical-building
+  dentist: tooth
+  drinking_water: water
+  ferry_terminal: ferry
+  fire_station: fire
+  food_court: restaurant
+  grave_yard: cemetery
+  camp_site: camping
+  wine: grapes
+  swimming: swimming_outdoor
+  swimming_pool: swimming_outdoor
+  #place_of_worship:
 
 # TODO c'est important ça comme recherche
 # Manquants mais secondaires
 #bbq:
 #community_centre:
 
-## Not in categories but still to be added as icons in useMapIcons
+
+# part 2/3 : using new icons not already described in moreCategories.yaml (added with round gray background)
 not in categories:
   office: building
   gallery: art_gallery
   castle:
 
-  # to be added as small icons without circle
+# part 3/3 : to be added as small icons without circle
 small:
   bollard:
   entrance: indoorequal-entrance

--- a/app/moreCategories.yaml
+++ b/app/moreCategories.yaml
@@ -247,7 +247,7 @@
   icon: cafe
 
 - name: Point d'eau
-  category: Bars et boisson
+  category: Divers # dans "Divers" plutôt que Boissons car c'est un usage pratique, non commercial de la boisson, plutôt qu'un usage "plaisir"
   dictionary:
     - boire
     - fontaine

--- a/app/moreCategories.yaml
+++ b/app/moreCategories.yaml
@@ -1,3 +1,12 @@
+# CATEGORY LIST (GROUPED BY THEME)
+# with expected properties :
+# - name
+# - category : name of the group of categories
+# - dictionnary : terms for text search bar
+# - query : for overpass
+# - icon : name of the svg file to be loaded
+# - icon alias (facultative) : new name for the icon in case the same svg is used in different category groups
+
 #######################
 # RESTAURANTS
 #######################
@@ -317,7 +326,7 @@
     - delicatessen
   query: '[shop=deli]'
   icon: shop
-  icon name: shop-food
+  icon alias: shop-food
 
 - name: Fromagerie
   category: Alimentation

--- a/app/moreCategories.yaml
+++ b/app/moreCategories.yaml
@@ -402,7 +402,9 @@
   query: '[shop=tea]'
   icon: tea
 
-################################
+#######################
+# LOISIRS
+#######################
 
 - name: Musique
   dictionary:
@@ -458,7 +460,9 @@
     - '[amenity=place_of_worship]'
   icon: place_of_worship
 
-################################
+#######################
+# SANTE
+#######################
 
 - name: hôpital
   category: Santé
@@ -515,7 +519,9 @@
   query: '[healthcare=midwife]'
   icon: nurse
 
-################################
+#######################
+# POUBELLES
+#######################
 
 - name: compost
   category: Poubelles
@@ -561,7 +567,9 @@
   query: '[amenity=recycling]["recycling:batteries"=yes]'
   icon: recycling
 
-################################
+#######################
+# CULTURE
+#######################
 
 - name: Journaux
   category: Culture
@@ -586,7 +594,9 @@
   query: '[shop="books"]'
   icon: book
 
-################################
+#######################
+# TOURISME
+#######################
 
 - name: Œuvre d'art
   category: Tourisme
@@ -644,7 +654,9 @@
   query: '[tourism~"camp_site|caravan_site"]'
   icon: camping
 
-################################
+#######################
+# COMMERCES NON ALIMENTAIRES
+#######################
 
 - name: Vêtements
   category: Commerces
@@ -660,6 +672,7 @@
     - chaussures
   query: '[shop=shoes]'
   icon: shoes
+  icon alias: shop-shoes
 - name: Centre commercial
   category: Commerces
   dictionary:
@@ -1178,7 +1191,9 @@
   query: '[sport=surfing]'
   icon: surf
 
-################################
+#######################
+# DIVERS
+#######################
 
 - name: Police
   category: Divers

--- a/app/svgo/bulk/route.ts
+++ b/app/svgo/bulk/route.ts
@@ -20,27 +20,23 @@ const groups = categories.reduce((memo, next) => {
 }, {})
 
 // on parcourt les groupes
-
 const icons = Object.entries(groups).map(([group, groupCategories]) => {
-	const groupColor = categoryColors[group] // on récupère la couleur du groupe
+	// on récupère la couleur du groupe
+	const groupColor = categoryColors[group]
 	// on parcourt les catégories
-
 	return groupCategories.map((category) => {
-		const imageFilename = category.icon // le nom du fichier svg en entrée
-		const imageFinalFilename = category['icon name'] // l'ID à utiliser en sortie (pour gérer les usages multiples d'un même svg d'entrée)
-		const imageName =
-			'cartesapp-' + // avoid collisions
-			(imageFinalFilename || imageFilename)
+		// on choisit le nom de l'icone : l'alias si précisé, sinon le nom du svg
+		const iconName = (category['icon alias'] || category.icon)
 		try {
 			// on récupère l'image svg et on ajoute le background correspondant à sa catégorie
 			const data = fs.readFileSync(
-				'./public/icons/' + imageFilename + '.svg',
+				'./public/icons/' + category.icon + '.svg',
 				'utf8'
 			)
 			const result = optimize(data, {})
 			const optimizedSvgString = result.data
 			const imgSrc = fromSvgToImgSrc(optimizedSvgString, groupColor)
-			return [imageName, imgSrc]
+			return [iconName, imgSrc]
 		} catch (e) {
 			console.error(e)
 		}
@@ -52,11 +48,11 @@ const fromCategories = icons.flat()
 // ETAPE 2/3 : icones hors catégories (listées dans imageRedirects.yaml : not in categories)
 
 const notInCategories = Object.entries(imageRedirects['not in categories'])
-	.map(([k, v]) => {
+	.map(([iconName, svgFilename]) => {
 		try {
 			// on récupère l'image svg et on ajoute le background correspondant à la catégorie "Divers"
 			const data = fs.readFileSync(
-				'./public/icons/' + (v || k) + '.svg',
+				'./public/icons/' + (svgFilename || iconName) + '.svg',
 				'utf8'
 			)
 			const result = optimize(data, {})
@@ -65,7 +61,7 @@ const notInCategories = Object.entries(imageRedirects['not in categories'])
 				optimizedSvgString,
 				categoryColors['Divers']
 			)
-			return ['cartesapp-' + k, imgSrc]
+			return [iconName, imgSrc]
 		} catch (e) {
 			console.error(e)
 		}
@@ -75,17 +71,17 @@ const notInCategories = Object.entries(imageRedirects['not in categories'])
 // ETAPE 3/3 : icones sans fond coloré (listées dans imageRedirects.yaml : small)
 
 const small = Object.entries(imageRedirects['small'])
-	.map(([k, v]) => {
+	.map(([iconName, svgFilename]) => {
 		try {
 			// on récupère l'image svg et on la laisse telle quelle
 			const data = fs.readFileSync(
-				'./public/icons/' + (v || k) + '.svg',
+				'./public/icons/' + (svgFilename || iconName) + '.svg',
 				'utf8'
 			)
 			const result = optimize(data, {})
 			const optimizedSvgString = result.data
-			const src = svgTextToDataImage(optimizedSvgString)
-			return ['cartesapp-' + k, src]
+			const imgSrc = svgTextToDataImage(optimizedSvgString)
+			return [iconName, imgSrc]
 		} catch (e) {
 			console.error(e)
 		}


### PR DESCRIPTION
J'ai documenté les scripts utilisés pour charger les icones sur la carte, en en profitant pour harmoniser les noms de variables entre les scripts.

J'enregistre en draft car en faisant ça j'ai cassé l'affichage des icones dans le menu, et je n'ai pas compris pourquoi, je veux bien que tu regardes, merci ! (L'affichage des icones sur le fond de carte, lui, fonctionne toujours)

Dans tous les cas, il vaudra mieux merger celle là avant #806

[EDIT] J'en ai profité pour enlever l'ajout de l'image quand on affiche les POI d'une catégorie, car on utilise l'image qui a déjà été chargée pour le fond de carte.
