### PR TITLE
gestion du clic sur les petits points d'ouverture des POI

### DIFF
--- a/app/effects/useDrawQuickSearchFeatures.ts
+++ b/app/effects/useDrawQuickSearchFeatures.ts
@@ -260,10 +260,17 @@ const draw = (
 		filter: ['!=', 'isOpenColor', false],
 	})
 
-	// gestion des actions en cas de de clic sur un POI
-	map.on('click', baseId + 'points', async (e) => {
+	// gestion des actions en cas de clic sur un POI (l'icone ou le cercle d'ouverture)
+	map.on('click', async (e) => {
+		//on teste si le clic a eu lieu dans l'un des 2 layers possibles, sinon on arrête
+		const features = map.queryRenderedFeatures(e.point, {
+			layers: [baseId + 'points', baseId + 'points-is-open']
+		});
+		if (!features.length) return
+		console.log("point trouvé au clic dans " + baseId)
+
 		// on charge les infos sur le POI
-		const feature = e.features[0]
+		const feature = features[0]
 		const { lng: longitude, lat: latitude } = e.lngLat
 		const properties = feature.properties,
 			tagsRaw = properties.tags
@@ -298,6 +305,12 @@ const draw = (
 		map.getCanvas().style.cursor = 'pointer'
 	})
 	map.on('mouseleave', baseId + 'points', () => {
+		map.getCanvas().style.cursor = ''
+	})
+	map.on('mouseenter', baseId + 'points-is-open', () => {
+		map.getCanvas().style.cursor = 'pointer'
+	})
+	map.on('mouseleave', baseId + 'points-is-open', () => {
 		map.getCanvas().style.cursor = ''
 	})
 }


### PR DESCRIPTION
Resolves #779 
Cette PR permet à l'utilisateur de cliquer sur les petits ronds d'ouverture des horaires quand (à zoom faible) l'icone d'un POI (chargé depuis les catégories) n'est pas affichée.

Review requise car je ne suis pas hyper satisfait, il y a toujours des cas où ça charge les infos d'un point, présent sur le fond de carte, proche du POI. J'ai l'impression qu'un clic sur la carte est analysé par différents `map.on('click', ...)` qui lancent chacun une action différente. Est-ce que ça serait imaginable d'avoir un seul gestionnaire de clic sur la carte qui gère les différents cas :
- si il y a des layers de POI affichés, on cherche d'abord dans ceux là
- sinon on cherche dans le fond de carte
mais j'imagine que ça n'est pas si simple et qu'il y a plein de cas à gérer ?