### PR TITLE
Choix des catégories à mettre en avant dans le menu

### DIFF
--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -60,9 +60,8 @@ export default function MoreCategories({
 										// on affiche la catégorie :
 										// - si il y a une recherche de texte en cours (pour qu'on voit les visible=false qui matchent)
 										// - ou si la catégorie est active (pour qu'on la voit et qu'on puisse la déselectionner)
-										// - ou sinon, si on a définit dans le yaml qu'on veut la mettre en avant (pour le menu initial)
 										// - ou enfin, si l'utilisateur a cliqué pour agrandir ce groupe
-										if (doFilter || isActive || category.highlight || showAllCategories) return (
+										if (doFilter || isActive || showAllCategories) return (
 											<Category
 												key={category.name}
 												$active={isActive}

--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -137,6 +137,7 @@ const Wrapper = styled.div`
 		margin: 0.4rem 0 0.1rem 0;
 		line-height: initial;
 		color: var(--darkerColor);
+		cursor: pointer;
 	}
 `
 const Group = styled.li`

--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -42,6 +42,9 @@ export default function MoreCategories({
 	return (
 		<Wrapper>
 			<ol>
+				{ !doFilter && //si pas de recherche en cours, on affiche ce message
+					<p>Astuce : utilisez la barre de recherche pour trouver des catégories</p>
+				}
 				{Object.entries(groups).map(([group, categories]) => {
 					const groupColor = categoryColors[group]
 					const showAllCategories = (group == largeGroup)
@@ -90,6 +93,12 @@ const Wrapper = styled.div`
 	margin-bottom: 0.6rem;
 	@media (max-width: 800px) {
 		margin-top: ${(p) => (p.$doFilter ? `0.6rem` : '0')};
+	}
+	p {
+		font-size: 75%;
+		margin: 0.4rem 0 0.1rem 0;
+		line-height: initial;
+		color: var(--darkerColor);
 	}
 	ol,
 	ul {

--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -43,7 +43,7 @@ export default function MoreCategories({
 		<Wrapper>
 			<ol>
 				{!doFilter && ( //si pas de recherche en cours, on affiche ce message
-					<p>
+					<p style={{ marginBottom: '.4rem' }}>
 						Astuce : utilisez la barre de recherche pour trouver des catégories
 					</p>
 				)}
@@ -58,9 +58,10 @@ export default function MoreCategories({
 							$groupColor={groupColor}
 							$expandGroup={expandGroup}
 						>
-							<h2 onClick={() => changeLargeGroup(group)}>
-								{group} {expandGroup ? '▲' : '▼'}
-							</h2>
+							<header onClick={() => changeLargeGroup(group)}>
+								<span></span>
+								<h2>{group}</h2>
+							</header>
 							<div>
 								<ul>
 									{categories.map((category) => {
@@ -85,6 +86,16 @@ export default function MoreCategories({
 										)
 									})}
 								</ul>
+								<HorizontalScrollExpandButton
+									onClick={() => changeLargeGroup(group)}
+								>
+									<Image
+										src={'/icons/more.svg'}
+										width="10"
+										height="10"
+										alt="Voir plus de groupes de recherche"
+									/>
+								</HorizontalScrollExpandButton>
 							</div>
 						</Group>
 					)
@@ -93,6 +104,33 @@ export default function MoreCategories({
 		</Wrapper>
 	)
 }
+
+const HorizontalScrollExpandButton = styled.button`
+	z-index: 10;
+	position: absolute;
+	right: -0.2rem;
+	top: 1.3rem;
+	width: 1.4rem;
+	height: 1.4rem;
+	padding: 0;
+	display: flex;
+	@media (min-width: 800px) {
+		display: none;
+	}
+	align-items: center;
+	justify-content: center;
+	background: white;
+	img {
+		padding: 0;
+		margin: 0;
+		width: 0.8rem;
+		height: auto;
+		filter: invert(78%) sepia(40%) saturate(225%) hue-rotate(171deg)
+			brightness(97%) contrast(99%);
+	}
+	border-radius: 1.6rem;
+	border: 2px solid var(--lighterColor);
+`
 
 const Wrapper = styled.div`
 	margin-bottom: 0.6rem;
@@ -140,26 +178,82 @@ const Wrapper = styled.div`
 			}
 		}
 	}
-	h2 {
-		font-size: 75%;
-		font-weight: 600;
-		text-transform: uppercase;
-		margin: 0.4rem 0 0.1rem 0;
-		line-height: initial;
-		color: var(--darkerColor);
+	header {
+		margin: 0.3rem 0 0.1rem 0;
+		display: flex;
+		align-items: center;
+		line-height: 1.2rem;
 		cursor: pointer;
+		h2 {
+			margin: 0;
+			font-size: 75%;
+			font-weight: 600;
+			text-transform: uppercase;
+			line-height: initial;
+			color: var(--darkerColor);
+		}
 	}
 `
 const Group = styled.li`
-	border-left: 4px solid ${(p) => p.$groupColor};
-	padding-left: 0.4rem;
-	div > ul {
-		/* Touch devices can scroll horizontally, desktop devices (hover:hover) cannot */
-		@media (hover: hover) {
-			flex-wrap: wrap;
+	> header > span {
+		display: ${(p) => (p.$expandGroup ? 'non' : 'block')};
+		@media (max-width: 800px) {
+			display: none;
 		}
-		@media (hover: none) {
-			flex-wrap: ${(p) => (p.$expandGroup ? `wrap` : `none`)};
+		width: 0.8rem;
+		height: 0.8rem;
+		background: ${(p) => p.$groupColor};
+		border-radius: 1rem;
+		margin-right: 0.3rem;
+	}
+	position: relative;
+	div {
+		&:after {
+			@media (min-width: 800px) {
+				display: none;
+			}
+			${(p) =>
+				p.$expandGroup
+					? css`
+							display: none;
+					  `
+					: ''}
+			content: '';
+			position: absolute;
+			z-index: 1;
+			top: 0.8rem;
+			right: 0;
+			bottom: 0;
+			pointer-events: none;
+			background-image: linear-gradient(
+				to right,
+				rgba(255, 255, 255, 0),
+				#ffffff 60%,
+				#ffffff 70%
+			);
+			width: 15%;
+		}
+
+		> ul {
+			@media (min-width: 800px) {
+				margin-top: 0.2rem;
+				margin-left: 0.3rem;
+				padding-left: 0.4rem;
+			}
+			${(p) =>
+				p.$expandGroup
+					? css`
+							padding-left: 0.4rem;
+							border-left: 2px solid ${(p) => p.$groupColor};
+					  `
+					: ''}
+			/* Touch devices can scroll horizontally, desktop devices (hover:hover) cannot */
+		@media (hover: hover) {
+				flex-wrap: wrap;
+			}
+			@media (hover: none) {
+				flex-wrap: ${(p) => (p.$expandGroup ? `wrap` : `none`)};
+			}
 		}
 	}
 `
@@ -202,4 +296,3 @@ function compareCategoryName(a, b) {
 	}
 	return 0
 }
-

--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -45,6 +45,8 @@ export default function MoreCategories({
 				{Object.entries(groups).map(([group, categories]) => {
 					const groupColor = categoryColors[group]
 					const showAllCategories = (group == largeGroup)
+					// tri des catégories par ordre alphabétique
+					categories.sort(compareCategoryName);
 					return (
 						<Group key={group} $groupColor={groupColor}>
 							<h2 onClick={() => changeLargeGroup(group)}>{group} {showAllCategories ? '▲' : '▼'}</h2>
@@ -167,3 +169,13 @@ const MapIconImage = styled(Image)`
 	vertical-align: sub;
 	margin-bottom: 0.05rem;
 `
+
+function compareCategoryName( a, b ) {
+  if ( a.name.toLowerCase() < b.name.toLowerCase() ){
+    return -1;
+  }
+  if ( a.name.toLowerCase() > b.name.toLowerCase() ){
+    return 1;
+  }
+  return 0;
+}

--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -33,7 +33,7 @@ export default function MoreCategories({
 	}, [setBulkImages])
 
 	// variable d'état pour stocker le groupe dont toutes les catégories sont affichées
-	const [largeGroup, setLargeGroup] = useState(false);
+	const [largeGroup, setLargeGroup] = useState(false)
 	// et fonction pour le modifier
 	function changeLargeGroup(group) {
 		setLargeGroup(group == largeGroup ? false : group)
@@ -42,17 +42,25 @@ export default function MoreCategories({
 	return (
 		<Wrapper>
 			<ol>
-				{ !doFilter && //si pas de recherche en cours, on affiche ce message
-					<p>Astuce : utilisez la barre de recherche pour trouver des catégories</p>
-				}
+				{!doFilter && ( //si pas de recherche en cours, on affiche ce message
+					<p>
+						Astuce : utilisez la barre de recherche pour trouver des catégories
+					</p>
+				)}
 				{Object.entries(groups).map(([group, categories]) => {
 					const groupColor = categoryColors[group]
-					const expandGroup = (group == largeGroup)
+					const expandGroup = group == largeGroup
 					// tri des catégories par ordre alphabétique
-					categories.sort(compareCategoryName);
+					categories.sort(compareCategoryName)
 					return (
-						<Group key={group} $groupColor={groupColor} $expandGroup={expandGroup}>
-							<h2 onClick={() => changeLargeGroup(group)}>{group} {expandGroup ? '▲' : '▼'}</h2>
+						<Group
+							key={group}
+							$groupColor={groupColor}
+							$expandGroup={expandGroup}
+						>
+							<h2 onClick={() => changeLargeGroup(group)}>
+								{group} {expandGroup ? '▲' : '▼'}
+							</h2>
 							<div>
 								<ul>
 									{categories.map((category) => {
@@ -185,12 +193,13 @@ const MapIconImage = styled(Image)`
 	margin-bottom: 0.05rem;
 `
 
-function compareCategoryName( a, b ) {
-  if ( a.name.toLowerCase() < b.name.toLowerCase() ){
-    return -1;
-  }
-  if ( a.name.toLowerCase() > b.name.toLowerCase() ){
-    return 1;
-  }
-  return 0;
+function compareCategoryName(a, b) {
+	if (a.name.toLowerCase() < b.name.toLowerCase()) {
+		return -1
+	}
+	if (a.name.toLowerCase() > b.name.toLowerCase()) {
+		return 1
+	}
+	return 0
 }
+

--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -118,9 +118,10 @@ const Wrapper = styled.div`
 		align-items: center;
 
 		/* Touch devices can scroll horizontally, desktop devices (hover:hover) cannot */
-		@media (hover: hover) {
+		// But scrolling is too long when many categories => wrap whatever the media
+		// @media (hover: hover) {
 			flex-wrap: wrap;
-		}
+		// }
 		li {
 			margin: 0.2rem 0.2rem;
 			padding: 0rem 0.3rem;

--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -32,14 +32,18 @@ export default function MoreCategories({
 		doFetch()
 	}, [setBulkImages])
 
+	// variable d'état pour stocker le groupe dont toutes les catégories sont affichées
+	const [largeGroup, setLargeGroup] = useState('Alimentation');
+
 	return (
 		<Wrapper>
 			<ol>
 				{Object.entries(groups).map(([group, categories]) => {
 					const groupColor = categoryColors[group]
+					const showAllCategories = (group == largeGroup)
 					return (
 						<Group key={group} $groupColor={groupColor}>
-							<h2>{group}</h2>
+							<h2 onClick={null}>{group} {showAllCategories ? '🔼' : '🔽'}</h2>
 							<div>
 								<ul>
 									{categories.map((category) => {
@@ -48,7 +52,8 @@ export default function MoreCategories({
 										// - si il y a une recherche de texte en cours (pour qu'on voit les visible=false qui matchent)
 										// - ou si la catégorie est active (pour qu'on la voit et qu'on puisse la déselectionner)
 										// - ou sinon, si on a définit dans le yaml qu'on veut la mettre en avant (pour le menu initial)
-										if (doFilter || isActive || category.highlight) return (
+										// - ou enfin, si l'utilisateur a cliqué pour agrandir ce groupe
+										if (doFilter || isActive || category.highlight || showAllCategories) return (
 											<Category
 												key={category.name}
 												$active={isActive}

--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -33,7 +33,11 @@ export default function MoreCategories({
 	}, [setBulkImages])
 
 	// variable d'état pour stocker le groupe dont toutes les catégories sont affichées
-	const [largeGroup, setLargeGroup] = useState('Alimentation');
+	const [largeGroup, setLargeGroup] = useState(false);
+	// et fonction pour le modifier
+	function changeLargeGroup(group) {
+		setLargeGroup(group == largeGroup ? false : group)
+	}
 
 	return (
 		<Wrapper>
@@ -43,7 +47,7 @@ export default function MoreCategories({
 					const showAllCategories = (group == largeGroup)
 					return (
 						<Group key={group} $groupColor={groupColor}>
-							<h2 onClick={null}>{group} {showAllCategories ? '🔼' : '🔽'}</h2>
+							<h2 onClick={() => changeLargeGroup(group)}>{group} {showAllCategories ? '▲' : '▼'}</h2>
 							<div>
 								<ul>
 									{categories.map((category) => {

--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -42,22 +42,29 @@ export default function MoreCategories({
 							<h2>{group}</h2>
 							<div>
 								<ul>
-									{categories.map((category) => (
-										<Category
-											key={category.name}
-											$active={categoriesSet.includes(category.name)}
-											$isExact={category.score < exactThreshold}
-										>
-											<Link href={getNewSearchParamsLink(category)}>
-												<MapIcon
-													category={category}
-													color={groupColor}
-													bulkImages={bulkImages}
-												/>{' '}
-												{uncapitalise0(category.title || category.name)}
-											</Link>
-										</Category>
-									))}
+									{categories.map((category) => {
+										const isActive = categoriesSet.includes(category.name)
+										// on affiche la catégorie :
+										// - si il y a une recherche de texte en cours (pour qu'on voit les visible=false qui matchent)
+										// - ou si la catégorie est active (pour qu'on la voit et qu'on puisse la déselectionner)
+										// - ou sinon, si on a définit dans le yaml qu'on veut la mettre en avant (pour le menu initial)
+										if (doFilter || isActive || category.highlight) return (
+											<Category
+												key={category.name}
+												$active={isActive}
+												$isExact={category.score < exactThreshold}
+											>
+												<Link href={getNewSearchParamsLink(category)}>
+													<MapIcon
+														category={category}
+														color={groupColor}
+														bulkImages={bulkImages}
+													/>{' '}
+													{uncapitalise0(category.title || category.name)}
+												</Link>
+											</Category>
+										)
+									})}
 								</ul>
 							</div>
 						</Group>

--- a/app/MoreCategories.tsx
+++ b/app/MoreCategories.tsx
@@ -47,25 +47,23 @@ export default function MoreCategories({
 				}
 				{Object.entries(groups).map(([group, categories]) => {
 					const groupColor = categoryColors[group]
-					const showAllCategories = (group == largeGroup)
+					const expandGroup = (group == largeGroup)
 					// tri des catégories par ordre alphabétique
 					categories.sort(compareCategoryName);
 					return (
-						<Group key={group} $groupColor={groupColor}>
-							<h2 onClick={() => changeLargeGroup(group)}>{group} {showAllCategories ? '▲' : '▼'}</h2>
+						<Group key={group} $groupColor={groupColor} $expandGroup={expandGroup}>
+							<h2 onClick={() => changeLargeGroup(group)}>{group} {expandGroup ? '▲' : '▼'}</h2>
 							<div>
 								<ul>
 									{categories.map((category) => {
 										const isActive = categoriesSet.includes(category.name)
-										// on affiche la catégorie :
-										// - si il y a une recherche de texte en cours (pour qu'on voit les visible=false qui matchent)
-										// - ou si la catégorie est active (pour qu'on la voit et qu'on puisse la déselectionner)
-										// - ou enfin, si l'utilisateur a cliqué pour agrandir ce groupe
-										if (doFilter || isActive || showAllCategories) return (
+										const display = doFilter || isActive || expandGroup
+										return (
 											<Category
 												key={category.name}
 												$active={isActive}
 												$isExact={category.score < exactThreshold}
+												$display={display}
 											>
 												<Link href={getNewSearchParamsLink(category)}>
 													<MapIcon
@@ -116,11 +114,6 @@ const Wrapper = styled.div`
 		display: flex;
 		align-items: center;
 
-		/* Touch devices can scroll horizontally, desktop devices (hover:hover) cannot */
-		// But scrolling is too long when many categories => wrap whatever the media
-		// @media (hover: hover) {
-			flex-wrap: wrap;
-		// }
 		li {
 			margin: 0.2rem 0.2rem;
 			padding: 0rem 0.3rem;
@@ -152,6 +145,15 @@ const Wrapper = styled.div`
 const Group = styled.li`
 	border-left: 4px solid ${(p) => p.$groupColor};
 	padding-left: 0.4rem;
+	div > ul {
+		/* Touch devices can scroll horizontally, desktop devices (hover:hover) cannot */
+		@media (hover: hover) {
+			flex-wrap: wrap;
+		}
+		@media (hover: none) {
+			flex-wrap: ${(p) => (p.$expandGroup ? `wrap` : `none`)};
+		}
+	}
 `
 
 const Category = styled.li`
@@ -164,6 +166,9 @@ const Category = styled.li`
 					border-color: var(--darkColor) !important;
 			  `
 			: ''}
+	@media (hover: hover) {
+		display: ${(p) => (p.$display ? `flex` : `none`)};
+	}
 `
 const MapIcon = ({ category, color, bulkImages }) => {
 	const src = bulkImages[category['icon alias'] || category['icon']]

--- a/app/moreCategories.yaml
+++ b/app/moreCategories.yaml
@@ -6,6 +6,7 @@
 # - query : for overpass
 # - icon : name of the svg file to be loaded
 # - icon alias (facultative) : new name for the icon in case the same svg is used in different category groups
+# - highlight (facutative) : true to display the category as example in the menu
 
 #######################
 # RESTAURANTS

--- a/app/moreCategories.yaml
+++ b/app/moreCategories.yaml
@@ -252,18 +252,6 @@
   icon: cafe
   highlight: true
 
-- name: Point d'eau
-  category: Divers # dans "Divers" plutôt que Boissons car c'est un usage pratique, non commercial de la boisson, plutôt qu'un usage "plaisir"
-  dictionary:
-    - boire
-    - fontaine
-    - eau potable
-    - robinet
-  query:
-    - '[amenity=drinking_water]'
-    - '[drinking_water=yes]'
-  icon: water
-
 - name: Salon de thé
   category: Bars et boisson
   dictionary:
@@ -1272,6 +1260,19 @@
   query: '[amenity=police]'
   icon: police
   highlight: true
+
+- name: Point d'eau
+  category: Divers # dans "Divers" plutôt que Boissons car c'est un usage pratique, non commercial de la boisson, plutôt qu'un usage "plaisir"
+  dictionary:
+    - boire
+    - fontaine
+    - eau potable
+    - robinet
+  query:
+    - '[amenity=drinking_water]'
+    - '[drinking_water=yes]'
+  icon: water
+
 - name: Agence postale
   category: Divers
   dictionary:

--- a/app/moreCategories.yaml
+++ b/app/moreCategories.yaml
@@ -6,7 +6,6 @@
 # - query : for overpass
 # - icon : name of the svg file to be loaded
 # - icon alias (facultative) : new name for the icon in case the same svg is used in different category groups
-# - highlight (facutative) : true to display the category as example in the menu
 
 #######################
 # RESTAURANTS
@@ -31,7 +30,6 @@
     '[amenity=restaurant][cuisine~crepe]'
     #icon: hermine ne marche pas :/
   icon: hermine
-  highlight: true
 
 - name: Restaurant étoilé
   category: Restaurants
@@ -97,7 +95,6 @@
     - '[food=pizza]'
     - '["food:pizza"=yes]'
   icon: restaurant
-  highlight: true
 
 - name: Libanais
   category: Restaurants
@@ -147,7 +144,6 @@
     - '["diet:vegetarian"~"yes|only"]'
     - '["diet:vegan"~"yes|only"]'
   icon: veg
-  highlight: true
 
 - name: Vegan
   category: Restaurants
@@ -181,7 +177,6 @@
     - '["amenity"="cafe"]'
     - '["amenity"="pub"]'
   icon: beer
-  highlight: true
 
 - name: Bar à bière
   category: Bars et boisson
@@ -250,7 +245,6 @@
     - '["amenity"="bar"]'
     - '["amenity"="cafe"]'
   icon: cafe
-  highlight: true
 
 - name: Salon de thé
   category: Bars et boisson
@@ -258,7 +252,6 @@
     - infusion
   query: '["cuisine"="teahouse"]'
   icon: tea
-  highlight: true
 
 #######################
 # COMMERCES DE BOUCHE
@@ -284,7 +277,6 @@
     - charcutier
   query: '[shop=butcher]'
   icon: meat
-  highlight: true
 
 - name: Boutique de café
   category: Alimentation
@@ -316,7 +308,6 @@
     - tablette
   query: '[shop=chocolate]'
   icon: chocolate
-  highlight: true
 
 - name: Épicerie fine
   category: Alimentation
@@ -377,7 +368,6 @@
     - légumes
   query: '[shop=greengrocer]'
   icon: grapes
-  highlight: true
 
 - name: Produits de la ferme
   category: Alimentation
@@ -419,7 +409,6 @@
     - '[amenity=theatre]' # Exemple : salle de concert à Brest https://www.openstreetmap.org/way/42531718#map=18/48.38500/-4.48092
   icon: music
   category: Loisirs
-  highlight: true
 
 - name: Théâtre
   dictionary:
@@ -429,7 +418,6 @@
     - '[amenity=theatre]' # Exemple : salle de concert à Brest https://www.openstreetmap.org/way/42531718#map=18/48.38500/-4.48092
   icon: theatre
   category: Loisirs
-  highlight: true
 
 - name: Jeux pour enfants
   category: Loisirs
@@ -442,7 +430,6 @@
     - '[landuse=recreation_ground]'
     - '[attraction=carousel]'
   icon: playground
-  highlight: true
 
 - name: lieu-culte
   title: Lieu de culte
@@ -492,13 +479,11 @@
     - généraliste
   query: '[amenity=doctors]'
   icon: doctors
-  highlight: true
 
 - name: Pharmacie
   category: Santé
   query: '[amenity=pharmacy]'
   icon: pharmacy
-  highlight: true
 
 - name: dentiste
   category: Santé
@@ -514,7 +499,6 @@
     - animaux
   query: '[amenity=veterinary]'
   icon: veterinary
-  highlight: true
 
 - name: infirmière
   category: Santé
@@ -544,7 +528,6 @@
     - déchets organiques
   query: '["recycling:organic"="yes"]'
   icon: recycling
-  highlight: true
 
 - name: verre
   category: Poubelles
@@ -552,7 +535,6 @@
     - bouteille
   query: '[amenity=recycling]["recycling:glass_bottles"=yes]'
   icon: recycling
-  highlight: true
 
 - name: vêtements
   category: Poubelles
@@ -578,7 +560,6 @@
     - '["recycling:paper"=yes]'
     - '["recycling:plastic_packaging"=yes]'
   icon: recycling
-  highlight: true
 
 - name: piles et batteries
   category: Poubelles
@@ -599,7 +580,6 @@
     - médiathèque
   query: '[amenity=library]'
   icon: book
-  highlight: true
 
 - name: Librairie
   category: Culture
@@ -608,7 +588,6 @@
     - bouquins
   query: '[shop="books"]'
   icon: book
-  highlight: true
 
 - name: Journaux
   category: Culture
@@ -618,7 +597,6 @@
     - presse
   query: '[shop~"newsagent|kiosk"]'
   icon: newspaper
-  highlight: true
 
 #######################
 # TOURISME
@@ -631,7 +609,6 @@
   query:
     - '[tourism=museum]'
   icon: museum
-  highlight: true
 
 - name: Œuvre d'art
   category: Tourisme
@@ -690,13 +667,11 @@
     - caravane
   query: '[tourism~"camp_site|caravan_site"]'
   icon: camping
-  highlight: true
 
 - name: plage
   category: Tourisme
   query: '[natural=beach]'
   icon: beach
-  highlight: true
 
 #######################
 # COMMERCES NON ALIMENTAIRES
@@ -709,7 +684,6 @@
     - fringues
   query: '[shop=clothes]'
   icon: clothes
-  highlight: true
 
 - name: Chaussures
   category: Commerces
@@ -719,7 +693,6 @@
   query: '[shop=shoes]'
   icon: shoes
   icon alias: shop-shoes
-  highlight: true
 
 - name: Centre commercial
   category: Commerces
@@ -737,7 +710,6 @@
     - colis
   query: '[amenity=parcel_locker]'
   icon: parcel_locker
-  highlight: true
 
 #######################
 # DÉPLACEMENTS
@@ -777,7 +749,6 @@
     - stationnement
   query: '[amenity=bicycle_parking]'
   icon: bicycle_parking
-  highlight: true
 
 - name: parking-velo-securise # pas d'accent pour que les url soient propres : toujours en 2024 les navigateurs (états-uniens) refusent une vision non états-unienne du Web sous prétexte de lutte contre le phishing
   title: Parking vélo sécurisé
@@ -838,7 +809,6 @@
     - borne
   query: '[amenity=charging_station]'
   icon: charging_station
-  highlight: true
 
 - name: Station de gonflage
   category: Déplacements
@@ -870,7 +840,6 @@
     - '[carpool=designated]'
     - '[amenity=car_pooling]'
   icon: car_pooling
-  highlight: true
 
 - name: Location de voiture
   category: Déplacements
@@ -891,7 +860,6 @@
     - fauteuil
   query: '[parking_space=disabled]'
   icon: wheelchair
-  highlight: true
 
 #######################
 # SPORTS
@@ -931,7 +899,6 @@
     - 🤾‍♀️
   query: '[leisure=sports_hall]'
   icon: gymnasium
-  highlight: true
 
 - name: Terrain multisport
   category: Sports
@@ -989,7 +956,6 @@
       # basin only  query: '[leisure=swimming_pool][access=yes]'
   query: '[leisure=sports_centre][sport=swimming]'
   icon: swimming_outdoor
-  highlight: true
 
 - name: Salle de musculation
   category: Sports
@@ -1092,7 +1058,6 @@
   query:
     - '["leisure"="pitch"][sport=skateboard]'
   icon: skateboard
-  highlight: true
 
 - name: Pumptrack
   category: Sports
@@ -1260,7 +1225,6 @@
     - comissariat
   query: '[amenity=police]'
   icon: police
-  highlight: true
 
 - name: Point d'eau
   category: Divers # dans "Divers" plutôt que Boissons car c'est un usage pratique, non commercial de la boisson, plutôt qu'un usage "plaisir"
@@ -1282,12 +1246,13 @@
     - la poste
   query: '[amenity=post_office]'
   icon: post
-  highlight: true
+
 - title: Coiffeur
   category: Divers
   name: coiffeur
   query: '[shop=hairdresser]'
   icon: hairdresser
+
 - title: Laverie
   category: Divers
   name: laverie
@@ -1302,7 +1267,7 @@
     - '[shop=laundry]'
     - '[shop=dry_cleaning]'
   icon: laundry
-  highlight: true
+
 - title: Espace de cotravail (coworking)
   category: Divers
   name: cotravail

--- a/app/moreCategories.yaml
+++ b/app/moreCategories.yaml
@@ -20,7 +20,6 @@
   query:
     - '[amenity=restaurant][cuisine~chinese]'
   icon: restaurant
-  highlight: true
 
 - name: Crêperie
   category: Restaurants
@@ -31,6 +30,7 @@
     '[amenity=restaurant][cuisine~crepe]'
     #icon: hermine ne marche pas :/
   icon: hermine
+  highlight: true
 
 - name: Restaurant étoilé
   category: Restaurants
@@ -53,7 +53,6 @@
     - kebab
   query: '[amenity=fast_food]'
   icon: fast_food
-  highlight: true
 
 - name: Cuisine française
   category: Restaurants
@@ -147,6 +146,7 @@
     - '["diet:vegetarian"~"yes|only"]'
     - '["diet:vegan"~"yes|only"]'
   icon: veg
+  highlight: true
 
 - name: Vegan
   category: Restaurants
@@ -222,7 +222,6 @@
     - sec
   query: '["drink:wine"]'
   icon: bottle
-  highlight: true
 
 - name: Bubble Tea
   category: Bars et boisson
@@ -258,6 +257,7 @@
     - infusion
   query: '["cuisine"="teahouse"]'
   icon: tea
+  highlight: true
 
 #######################
 # COMMERCES DE BOUCHE
@@ -273,11 +273,11 @@
   #emoji: 🥖
   query: '[shop=bakery]'
   icon: bakery
-  highlight: true
 
 - name: Boucherie
   category: Alimentation
   dictionary:
+    - boucher
     - viande
     - charcuterie
     - charcutier
@@ -332,7 +332,6 @@
     - traiteur
   query: '[shop=cheese]'
   icon: cheese
-  highlight: true
 
 - name: Glacier
   category: Alimentation
@@ -341,7 +340,6 @@
     - sorbet
   query: '[shop=ice_cream]'
   icon: ice_cream
-  highlight: true
 
 - name: Miellerie
   category: Alimentation
@@ -432,11 +430,6 @@
   category: Loisirs
   highlight: true
 
-- name: plage
-  category: Tourisme
-  query: '[natural=beach]'
-  icon: beach
-
 - name: Jeux pour enfants
   category: Loisirs
   dictionary:
@@ -448,6 +441,7 @@
     - '[landuse=recreation_ground]'
     - '[attraction=carousel]'
   icon: playground
+  highlight: true
 
 - name: lieu-culte
   title: Lieu de culte
@@ -489,7 +483,6 @@
     - '[amenity=clinic]'
     - '[healthcare=clinic]'
   icon: hospital
-  highlight: true
 
 - name: médecin
   category: Santé
@@ -520,6 +513,7 @@
     - animaux
   query: '[amenity=veterinary]'
   icon: veterinary
+  highlight: true
 
 - name: infirmière
   category: Santé
@@ -527,7 +521,6 @@
     - infirmière
   query: '[healthcare=nurse]'
   icon: nurse
-  highlight: true
 
 - name: sage-femme
   category: Santé
@@ -550,6 +543,7 @@
     - déchets organiques
   query: '["recycling:organic"="yes"]'
   icon: recycling
+  highlight: true
 
 - name: verre
   category: Poubelles
@@ -567,9 +561,10 @@
   query: '[amenity=recycling]["recycling:clothes"=yes]'
   icon: recycling
 
-- name: plastique et emballages
+- name: emballages
   category: Poubelles
   dictionary:
+    - plastique
     - canette
     - carton
     - papier
@@ -596,15 +591,6 @@
 # CULTURE
 #######################
 
-- name: Journaux
-  category: Culture
-  dictionary:
-    - kiosque
-    - magazines
-    - presse
-  query: '[shop~"newsagent|kiosk"]'
-  icon: newspaper
-
 - name: Bibliothèque
   category: Culture
   dictionary:
@@ -621,6 +607,16 @@
     - bouquins
   query: '[shop="books"]'
   icon: book
+  highlight: true
+
+- name: Journaux
+  category: Culture
+  dictionary:
+    - kiosque
+    - magazines
+    - presse
+  query: '[shop~"newsagent|kiosk"]'
+  icon: newspaper
   highlight: true
 
 #######################
@@ -672,7 +668,6 @@
     - nature
   query: '[tourism=information]'
   icon: information
-  highlight: true
 
 - name: Pique-nique
   category: Tourisme
@@ -694,6 +689,13 @@
     - caravane
   query: '[tourism~"camp_site|caravan_site"]'
   icon: camping
+  highlight: true
+
+- name: plage
+  category: Tourisme
+  query: '[natural=beach]'
+  icon: beach
+  highlight: true
 
 #######################
 # COMMERCES NON ALIMENTAIRES
@@ -725,7 +727,6 @@
     - shopping
   query: '[shop=mall]'
   icon: shop
-  highlight: true
 
 - name: Casier à colis
   category: Commerces
@@ -735,6 +736,7 @@
     - colis
   query: '[amenity=parcel_locker]'
   icon: parcel_locker
+  highlight: true
 
 #######################
 # DÉPLACEMENTS
@@ -750,7 +752,6 @@
     - TER
   query: '[public_transport=station][train=yes]'
   icon: train
-  highlight: true
 
 - name: magasin-velo
   title: Magasin vélo
@@ -878,7 +879,6 @@
     - véhicule
   query: '[amenity=car_rental]'
   icon: mx_amenity_car_rental
-  highlight: true
 
 - name: Place PMR
   category: Déplacements
@@ -1329,7 +1329,6 @@
     - '[amenity=grave_yard]'
     - '[landuse=cemetery]'
   icon: cemetery
-  highlight: true
 
 ## Peut-être carrément une catégorie "services publics"
 ## https://wiki.openstreetmap.org/wiki/France/Services_Publics

--- a/app/moreCategories.yaml
+++ b/app/moreCategories.yaml
@@ -20,6 +20,7 @@
   query:
     - '[amenity=restaurant][cuisine~chinese]'
   icon: restaurant
+  highlight: true
 
 - name: Crêperie
   category: Restaurants
@@ -52,6 +53,7 @@
     - kebab
   query: '[amenity=fast_food]'
   icon: fast_food
+  highlight: true
 
 - name: Cuisine française
   category: Restaurants
@@ -95,6 +97,7 @@
     - '[food=pizza]'
     - '["food:pizza"=yes]'
   icon: restaurant
+  highlight: true
 
 - name: Libanais
   category: Restaurants
@@ -177,6 +180,7 @@
     - '["amenity"="cafe"]'
     - '["amenity"="pub"]'
   icon: beer
+  highlight: true
 
 - name: Bar à bière
   category: Bars et boisson
@@ -218,6 +222,7 @@
     - sec
   query: '["drink:wine"]'
   icon: bottle
+  highlight: true
 
 - name: Bubble Tea
   category: Bars et boisson
@@ -245,6 +250,7 @@
     - '["amenity"="bar"]'
     - '["amenity"="cafe"]'
   icon: cafe
+  highlight: true
 
 - name: Point d'eau
   category: Divers # dans "Divers" plutôt que Boissons car c'est un usage pratique, non commercial de la boisson, plutôt qu'un usage "plaisir"
@@ -279,6 +285,7 @@
   #emoji: 🥖
   query: '[shop=bakery]'
   icon: bakery
+  highlight: true
 
 - name: Boucherie
   category: Alimentation
@@ -288,6 +295,7 @@
     - charcutier
   query: '[shop=butcher]'
   icon: meat
+  highlight: true
 
 - name: Boutique de café
   category: Alimentation
@@ -319,6 +327,7 @@
     - tablette
   query: '[shop=chocolate]'
   icon: chocolate
+  highlight: true
 
 - name: Épicerie fine
   category: Alimentation
@@ -335,6 +344,7 @@
     - traiteur
   query: '[shop=cheese]'
   icon: cheese
+  highlight: true
 
 - name: Glacier
   category: Alimentation
@@ -343,6 +353,7 @@
     - sorbet
   query: '[shop=ice_cream]'
   icon: ice_cream
+  highlight: true
 
 - name: Miellerie
   category: Alimentation
@@ -379,6 +390,7 @@
     - légumes
   query: '[shop=greengrocer]'
   icon: grapes
+  highlight: true
 
 - name: Produits de la ferme
   category: Alimentation
@@ -420,6 +432,7 @@
     - '[amenity=theatre]' # Exemple : salle de concert à Brest https://www.openstreetmap.org/way/42531718#map=18/48.38500/-4.48092
   icon: music
   category: Loisirs
+  highlight: true
 
 - name: Théâtre
   dictionary:
@@ -429,6 +442,7 @@
     - '[amenity=theatre]' # Exemple : salle de concert à Brest https://www.openstreetmap.org/way/42531718#map=18/48.38500/-4.48092
   icon: theatre
   category: Loisirs
+  highlight: true
 
 - name: plage
   category: Tourisme
@@ -487,6 +501,8 @@
     - '[amenity=clinic]'
     - '[healthcare=clinic]'
   icon: hospital
+  highlight: true
+
 - name: médecin
   category: Santé
   dictionary:
@@ -494,10 +510,14 @@
     - généraliste
   query: '[amenity=doctors]'
   icon: doctors
+  highlight: true
+
 - name: Pharmacie
   category: Santé
   query: '[amenity=pharmacy]'
   icon: pharmacy
+  highlight: true
+
 - name: dentiste
   category: Santé
   dictionary:
@@ -505,18 +525,22 @@
     - médecin
   query: '[amenity=dentist]'
   icon: tooth
+
 - name: vétérinaire
   category: Santé
   dictionary:
     - animaux
   query: '[amenity=veterinary]'
   icon: veterinary
+
 - name: infirmière
   category: Santé
   dictionary:
     - infirmière
   query: '[healthcare=nurse]'
   icon: nurse
+  highlight: true
+
 - name: sage-femme
   category: Santé
   dictionary:
@@ -538,12 +562,15 @@
     - déchets organiques
   query: '["recycling:organic"="yes"]'
   icon: recycling
+
 - name: verre
   category: Poubelles
   dictionary:
     - bouteille
   query: '[amenity=recycling]["recycling:glass_bottles"=yes]'
   icon: recycling
+  highlight: true
+
 - name: vêtements
   category: Poubelles
   dictionary:
@@ -551,6 +578,7 @@
     - tissus
   query: '[amenity=recycling]["recycling:clothes"=yes]'
   icon: recycling
+
 - name: plastique et emballages
   category: Poubelles
   dictionary:
@@ -566,6 +594,8 @@
     - '["recycling:paper"=yes]'
     - '["recycling:plastic_packaging"=yes]'
   icon: recycling
+  highlight: true
+
 - name: piles et batteries
   category: Poubelles
   dictionary:
@@ -586,6 +616,7 @@
     - presse
   query: '[shop~"newsagent|kiosk"]'
   icon: newspaper
+
 - name: Bibliothèque
   category: Culture
   dictionary:
@@ -593,6 +624,8 @@
     - médiathèque
   query: '[amenity=library]'
   icon: book
+  highlight: true
+
 - name: Librairie
   category: Culture
   dictionary:
@@ -600,6 +633,7 @@
     - bouquins
   query: '[shop="books"]'
   icon: book
+  highlight: true
 
 #######################
 # TOURISME
@@ -612,6 +646,7 @@
   query:
     - '[tourism=museum]'
   icon: museum
+  highlight: true
 
 - name: Œuvre d'art
   category: Tourisme
@@ -649,6 +684,8 @@
     - nature
   query: '[tourism=information]'
   icon: information
+  highlight: true
+
 - name: Pique-nique
   category: Tourisme
   dictionary:
@@ -659,6 +696,7 @@
     - casse-croute
   query: '[tourism=picnic_site]'
   icon: picnic
+
 - name: Camping
   category: Tourisme
   dictionary:
@@ -680,6 +718,8 @@
     - fringues
   query: '[shop=clothes]'
   icon: clothes
+  highlight: true
+
 - name: Chaussures
   category: Commerces
   dictionary:
@@ -688,6 +728,8 @@
   query: '[shop=shoes]'
   icon: shoes
   icon alias: shop-shoes
+  highlight: true
+
 - name: Centre commercial
   category: Commerces
   dictionary:
@@ -695,6 +737,8 @@
     - shopping
   query: '[shop=mall]'
   icon: shop
+  highlight: true
+
 - name: Casier à colis
   category: Commerces
   dictionary:
@@ -718,6 +762,8 @@
     - TER
   query: '[public_transport=station][train=yes]'
   icon: train
+  highlight: true
+
 - name: magasin-velo
   title: Magasin vélo
   category: Déplacements
@@ -741,6 +787,7 @@
     - stationnement
   query: '[amenity=bicycle_parking]'
   icon: bicycle_parking
+  highlight: true
 
 - name: parking-velo-securise # pas d'accent pour que les url soient propres : toujours en 2024 les navigateurs (états-uniens) refusent une vision non états-unienne du Web sous prétexte de lutte contre le phishing
   title: Parking vélo sécurisé
@@ -801,6 +848,7 @@
     - borne
   query: '[amenity=charging_station]'
   icon: charging_station
+  highlight: true
 
 - name: Station de gonflage
   category: Déplacements
@@ -832,6 +880,7 @@
     - '[carpool=designated]'
     - '[amenity=car_pooling]'
   icon: car_pooling
+  highlight: true
 
 - name: Location de voiture
   category: Déplacements
@@ -841,6 +890,7 @@
     - véhicule
   query: '[amenity=car_rental]'
   icon: mx_amenity_car_rental
+  highlight: true
 
 - name: Place PMR
   category: Déplacements
@@ -852,6 +902,7 @@
     - fauteuil
   query: '[parking_space=disabled]'
   icon: wheelchair
+  highlight: true
 
 #######################
 # SPORTS
@@ -891,6 +942,7 @@
     - 🤾‍♀️
   query: '[leisure=sports_hall]'
   icon: gymnasium
+  highlight: true
 
 - name: Terrain multisport
   category: Sports
@@ -948,6 +1000,7 @@
       # basin only  query: '[leisure=swimming_pool][access=yes]'
   query: '[leisure=sports_centre][sport=swimming]'
   icon: swimming_outdoor
+  highlight: true
 
 - name: Salle de musculation
   category: Sports
@@ -1050,6 +1103,7 @@
   query:
     - '["leisure"="pitch"][sport=skateboard]'
   icon: skateboard
+  highlight: true
 
 - name: Pumptrack
   category: Sports
@@ -1217,6 +1271,7 @@
     - comissariat
   query: '[amenity=police]'
   icon: police
+  highlight: true
 - name: Agence postale
   category: Divers
   dictionary:
@@ -1225,6 +1280,7 @@
     - la poste
   query: '[amenity=post_office]'
   icon: post
+  highlight: true
 - title: Coiffeur
   category: Divers
   name: coiffeur
@@ -1244,6 +1300,7 @@
     - '[shop=laundry]'
     - '[shop=dry_cleaning]'
   icon: laundry
+  highlight: true
 - title: Espace de cotravail (coworking)
   category: Divers
   name: cotravail
@@ -1271,6 +1328,7 @@
     - '[amenity=grave_yard]'
     - '[landuse=cemetery]'
   icon: cemetery
+  highlight: true
 
 ## Peut-être carrément une catégorie "services publics"
 ## https://wiki.openstreetmap.org/wiki/France/Services_Publics


### PR DESCRIPTION
Suite à discussion dans #721 je propose de modifier le menu des catégories pour :
- ✅​ afficher seulement 3 catégories _mises en avant_ dans le .yaml avec une propriété facultative `highlight=true` 
  - tout en gérant la recherche pour qu'elle affiche toutes les catégories (qu'elles soient mises en avant ou non)
  - et en affichant aussi les catégories actives (celles affichées sur la carte) pour qu'on puisse les déselectionner
- [EDIT:] ✅  avoir un bouton discret pour pouvoir agrandir un groupe et afficher toutes ses catégories)

ça donne ceci :
- par défaut les catégories n'affichent que les 3 catégories indiqués dans le .yaml
- `alimentation` affiche en plus `fromagerie` car il a été sélectionné par l'utilisateur pour affichage sur la carte
- `santé` affiche tout car l'utilisateur a agrandi ce groupe en cliquant sur le petite triangle

![image](https://github.com/user-attachments/assets/f76e01d9-e356-4cf4-a63e-dd8cf51f4742)
