### PR TITLE
Arrêts de bus v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ public/indoorequal/
 # Sentry Config File
 .env.sentry-build-plugin
 public/communes*
+.env
+.env

--- a/app/ShareButton.tsx
+++ b/app/ShareButton.tsx
@@ -25,8 +25,8 @@ export default function ShareButton({ osmFeature, geocodedClickedPoint }) {
 				? buildAllezPart(
 						osmFeature.tags?.name,
 						encodePlace(osmFeature.type, osmFeature.id),
-						osmFeature.lon,
-						osmFeature.lat
+						osmFeature.lon || osmFeature.longitude, // I dunno why, some osmFeature builder somewhere sets longitude but not lon; same for lat
+						osmFeature.lat || osmFeature.latitude
 				  )
 				: buildAllezPart(
 						'Point sur la carte',

--- a/app/effects/useMapClick.ts
+++ b/app/effects/useMapClick.ts
@@ -84,10 +84,13 @@ export default function useMapClick(
 
 			if (circo) return setSearchParams({ ...circo })
 
+			const interesting = rawFeatures.filter(
+				(feature) => feature.source !== 'searchPolygon'
+			)
 			console.log(
 				'clicked map features',
-				rawFeatures && rawFeatures[0].properties,
-				rawFeatures
+				interesting && interesting[0],
+				interesting
 			)
 
 			if (!features.length || !features[0].id) {

--- a/app/osmRequest.ts
+++ b/app/osmRequest.ts
@@ -115,7 +115,10 @@ export const osmRequest = async (featureType, id, full) => {
 		}
 		return elements
 	} catch (e) {
-		console.error('Probably a network error fetching OSM feature via Overpass')
+		console.error(
+			'Probably a network error fetching OSM feature via Overpass',
+			e
+		)
 		return [{ id, failedServerOsmRequest: true, type: featureType }]
 	}
 }

--- a/app/serverUrls.ts
+++ b/app/serverUrls.ts
@@ -16,7 +16,6 @@ export const motisServerUrl =
 export const photonServerUrl = process.env.NEXT_PUBLIC_PHOTON_SERVER_URL
 
 export const getFetchUrlBase = () => {
-	console.log('monenv', process.env)
 	const givenDomain = process.env.NEXT_PUBLIC_DOMAIN
 	// Coolify has a similar way to Vercel to inject the domain, but Dokploy has not
 	if (givenDomain) return 'https://' + givenDomain

--- a/app/transport/StopByName.tsx
+++ b/app/transport/StopByName.tsx
@@ -21,10 +21,9 @@ export default function StopByName({ stopName, data }) {
 		[stopName]
 	)
 
-	console.log('purple data', data, stopIds)
+	console.log('olive stopByName data', data, stopIds)
 
 	const entries = useTransportStopData(null, stopIds.length ? stopIds : null)
-	console.log('purple trips', entries)
 	const sorted = sortBy(([, { trips }]) => -trips.length)(entries)
 
 	return sorted.map(([id, data]) => <StopById key={id} data={data} />)

--- a/app/transport/stop/Route.tsx
+++ b/app/transport/stop/Route.tsx
@@ -86,26 +86,29 @@ export default function Route({ route, stops = [] }) {
 			}
 
 			// Process calendar.txt regular service
-			if (stop.trip.calendar) {
-				const calendar = stop.trip.calendar
+			if (stop.trip.calendar && stop.trip.calendar.length) {
+				const calendars = stop.trip.calendar
 				const today = new Date()
-				const startDate = new Date(calendar.start_date.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3'))
-				const endDate = new Date(calendar.end_date.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3'))
+				
+				// Process each calendar entry
+				calendars.forEach(calendar => {
+					const startDate = new Date(calendar.start_date.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3'))
+					const endDate = new Date(calendar.end_date.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3'))
 
-				// Get all dates between start and end where the service runs
-				for (let d = startDate; d <= endDate; d.setDate(d.getDate() + 1)) {
-					const day = d.getDay()
-					const dayMap = {
-						0: 'sunday',
-						1: 'monday',
-						2: 'tuesday',
-						3: 'wednesday',
-						4: 'thursday',
-						5: 'friday',
-						6: 'saturday'
-					}
-					
-					if (calendar[dayMap[day]] === '1') {
+					// Get all dates between start and end where the service runs
+					for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+						const day = d.getDay()
+						const dayMap = {
+							0: 'sunday',
+							1: 'monday',
+							2: 'tuesday',
+							3: 'wednesday',
+							4: 'thursday',
+							5: 'friday',
+							6: 'saturday'
+						}
+						
+						if (calendar[dayMap[day]] === '1') {
 						const year = d.getFullYear()
 						const month = String(d.getMonth() + 1).padStart(2, '0')
 						const dayOfMonth = String(d.getDate()).padStart(2, '0')

--- a/app/transport/stop/Route.tsx
+++ b/app/transport/stop/Route.tsx
@@ -128,8 +128,9 @@ export default function Route({ route, stops = [] }) {
 									day: `${year}-${month}-${dayOfMonth}`,
 								})
 							}
+						}
 					}
-				}
+				})
 			}
 
 			return dates.map((el) => ({ ...omit(['trip'], stop), ...el }))

--- a/app/transport/stop/Route.tsx
+++ b/app/transport/stop/Route.tsx
@@ -190,6 +190,7 @@ export default function Route({ route, stops = [] }) {
 		name = nameParts
 			? (direction === 1 ? nameParts.reverse() : nameParts).join(' → ')
 			: rawName
+	console.log('olive stop route', route, direction, nameParts, name, stops)
 
 	return (
 		<RouteLi>

--- a/app/transport/stop/Route.tsx
+++ b/app/transport/stop/Route.tsx
@@ -59,7 +59,7 @@ export default function Route({ route, stops = [] }) {
 			// in Bretagne unified GTFS, all the GTFS were normalized with a technique where each trip has one calendar date entry only
 			// Handle both calendar.txt and calendar_dates.txt
 			let dates = []
-			
+
 			// Process calendar_dates.txt exceptions
 			if (stop.trip.calendarDates) {
 				const calendarDates = stop.trip.calendarDates
@@ -89,7 +89,7 @@ export default function Route({ route, stops = [] }) {
 			if (stop.trip.calendar && stop.trip.calendar.length) {
 				const calendars = stop.trip.calendar
 				const today = new Date()
-				
+
 				// Process each calendar entry
 				calendars.forEach(calendar => {
 					const startDate = new Date(calendar.start_date.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3'))
@@ -107,13 +107,13 @@ export default function Route({ route, stops = [] }) {
 							5: 'friday',
 							6: 'saturday'
 						}
-						
+
 						if (calendar[dayMap[day]] === '1') {
 						const year = d.getFullYear()
 						const month = String(d.getMonth() + 1).padStart(2, '0')
 						const dayOfMonth = String(d.getDate()).padStart(2, '0')
-						const arrivalDate = toDate({ year, month, dayOfMonth }, time)
-						
+						const arrivalDate = toDate({ year, month, day: dayOfMonth }, time)
+
 						const isFuture = arrivalDate > now
 						dates.push({
 							isFuture,

--- a/app/transport/stop/Route.tsx
+++ b/app/transport/stop/Route.tsx
@@ -88,15 +88,28 @@ export default function Route({ route, stops = [] }) {
 			// Process calendar.txt regular service
 			if (stop.trip.calendar && stop.trip.calendar.length) {
 				const calendars = stop.trip.calendar
-				const today = new Date()
 
 				// Process each calendar entry
-				calendars.forEach(calendar => {
-					const startDate = new Date(calendar.start_date.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3'))
-					const endDate = new Date(calendar.end_date.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3'))
+				calendars.forEach((calendar) => {
+					const startDate = new Date(
+						('' + calendar.start_date).replace(
+							/(\d{4})(\d{2})(\d{2})/,
+							'$1-$2-$3'
+						)
+					)
+					const endDate = new Date(
+						('' + calendar.end_date).replace(
+							/(\d{4})(\d{2})(\d{2})/,
+							'$1-$2-$3'
+						)
+					)
 
 					// Get all dates between start and end where the service runs
-					for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+					for (
+						let d = new Date(startDate);
+						d <= endDate;
+						d.setDate(d.getDate() + 1)
+					) {
 						const day = d.getDay()
 						const dayMap = {
 							0: 'sunday',
@@ -105,22 +118,29 @@ export default function Route({ route, stops = [] }) {
 							3: 'wednesday',
 							4: 'thursday',
 							5: 'friday',
-							6: 'saturday'
+							6: 'saturday',
 						}
 
-						if (calendar[dayMap[day]] === '1') {
+						console.log('cyan calendar', dayMap[day])
+
+						if (calendar[dayMap[day]] === 1) {
 							const year = d.getFullYear()
 							const month = String(d.getMonth() + 1).padStart(2, '0')
 							const dayOfMonth = String(d.getDate()).padStart(2, '0')
-							
+
 							// Check if this date is not cancelled by an exception in calendarDates
 							const formattedDate = parseInt(`${year}${month}${dayOfMonth}`)
 							const isDateCancelled = stop.trip.calendarDates?.some(
-								exception => exception.date === formattedDate && exception.exception_type === 2
+								(exception) =>
+									exception.date === formattedDate &&
+									exception.exception_type === 2
 							)
 
 							if (!isDateCancelled) {
-								const arrivalDate = toDate({ year, month, day: dayOfMonth }, time)
+								const arrivalDate = toDate(
+									{ year, month, day: dayOfMonth },
+									time
+								)
 								const isFuture = arrivalDate > now
 								dates.push({
 									isFuture,

--- a/app/transport/stop/Route.tsx
+++ b/app/transport/stop/Route.tsx
@@ -121,8 +121,6 @@ export default function Route({ route, stops = [] }) {
 							6: 'saturday',
 						}
 
-						console.log('cyan calendar', dayMap[day])
-
 						if (calendar[dayMap[day]] === 1) {
 							const year = d.getFullYear()
 							const month = String(d.getMonth() + 1).padStart(2, '0')

--- a/app/transport/stop/Route.tsx
+++ b/app/transport/stop/Route.tsx
@@ -169,39 +169,38 @@ export default function Route({ route, stops = [] }) {
 
 	const stopSelection = stopsToday.filter((el) => el.isFuture).slice(0, 4)
 
+	const headSigns = stops[0].trip.trip_headsign != null && [
+		...new Set(stops.map((stop) => stop.trip.trip_headsign)),
+	]
+	const destinations = !headSigns && [
+		...new Set(stops.map((stop) => stop.trip.destination)),
+	]
+
+	const safeDestinations = headSigns || destinations
+	const name = safeDestinations[0]
 	const directions = stops.map(({ trip }) => trip.direction_id)
 	const otherDirection = directions[0] === 0 ? 1 : 0
 	const index = directions.findIndex((i) => i === otherDirection)
 	const hasMultipleTripDirections = index > -1
-	const direction = directions[0],
-		rawName =
-			route.route_long_name || route.route_short_name || 'ligne sans nom',
-		// Here we're deriving the directed name from the raw name. They don't help
-		// us here :D haven't found a better way to display the correct trip name...
-		//
-		//"Rennes (La Poterie)  Vezin-le-Coquet (ZI Ouest)"
-		// "Cesson-Sévigné (Cesson - Viasilva)  Rennes   Chantepie (Rosa Parks)"
-		nameParts = rawName.match(/\s\s/)
-			? rawName.split(/\s\s/)
-			: // "PLOUZANÉ Bourg - BREST Amiral Ronarc’h"
-			rawName.match(/\s-\s/)
-			? rawName.split(/\s-\s/)
-			: null,
-		name = nameParts
-			? (direction === 1 ? nameParts.reverse() : nameParts).join(' → ')
-			: rawName
-	console.log('olive stop route', route, direction, nameParts, name, stops)
+	console.log('olive stop route', route, name, stops) // direction, nameParts, name, stops)
 
 	return (
 		<RouteLi>
 			<RouteName route={route} name={name} />
-			{route.route_type === 3 && hasMultipleTripDirections && (
+			{route.route_type === 3 &&
+				hasMultipleTripDirections && ( // this route_type is probably here because lots of metro stations are unique with obviously two directions, without a potential for misunderstanding
+					<div>
+						<span>⚠️</span>
+						<small>
+							Attention, plusieurs directions d'une même ligne de bus s'arrêtent
+							à cet arrêt.
+						</small>
+					</div>
+				)}
+			{safeDestinations.length > 1 && (
 				<div>
 					<span>⚠️</span>
-					<small>
-						Attention, plusieurs directions d'une même ligne de bus s'arrêtent à
-						cet arrêt.
-					</small>
+					<small>Attention, cette ligne a plusieurs destinations.</small>
 				</div>
 			)}
 			<ul>

--- a/app/transport/stop/Route.tsx
+++ b/app/transport/stop/Route.tsx
@@ -109,17 +109,25 @@ export default function Route({ route, stops = [] }) {
 						}
 
 						if (calendar[dayMap[day]] === '1') {
-						const year = d.getFullYear()
-						const month = String(d.getMonth() + 1).padStart(2, '0')
-						const dayOfMonth = String(d.getDate()).padStart(2, '0')
-						const arrivalDate = toDate({ year, month, day: dayOfMonth }, time)
+							const year = d.getFullYear()
+							const month = String(d.getMonth() + 1).padStart(2, '0')
+							const dayOfMonth = String(d.getDate()).padStart(2, '0')
+							
+							// Check if this date is not cancelled by an exception in calendarDates
+							const formattedDate = parseInt(`${year}${month}${dayOfMonth}`)
+							const isDateCancelled = stop.trip.calendarDates?.some(
+								exception => exception.date === formattedDate && exception.exception_type === 2
+							)
 
-						const isFuture = arrivalDate > now
-						dates.push({
-							isFuture,
-							arrivalDate,
-							day: `${year}-${month}-${dayOfMonth}`,
-						})
+							if (!isDateCancelled) {
+								const arrivalDate = toDate({ year, month, day: dayOfMonth }, time)
+								const isFuture = arrivalDate > now
+								dates.push({
+									isFuture,
+									arrivalDate,
+									day: `${year}-${month}-${dayOfMonth}`,
+								})
+							}
 					}
 				}
 			}

--- a/app/transport/useTransportStopData.ts
+++ b/app/transport/useTransportStopData.ts
@@ -11,12 +11,11 @@ export default function useTransportStopData(osmFeature, gtfsStopIds) {
 
 		const doFetch = async () => {
 			try {
-				const response = await fetch(
-					gtfsServerUrl + `/geoStops/${osmFeature.lat}/${osmFeature.lon}/50`,
-					{
-						mode: 'cors',
-					}
-				)
+				const url =
+					gtfsServerUrl + `/geoStops/${osmFeature.lat}/${osmFeature.lon}/50`
+				const response = await fetch(url, {
+					mode: 'cors',
+				})
 
 				const json = await response.json()
 
@@ -31,7 +30,7 @@ export default function useTransportStopData(osmFeature, gtfsStopIds) {
 				)
 				const firstMatch = await firstMatchResponse.json()
 
-				console.log('magenta stops', json, firstMatch)
+				console.log('magenta stops for request ', url, json, firstMatch)
 
 				setData(firstMatch)
 			} catch (e) {

--- a/components/map/CartesProtocol.ts
+++ b/components/map/CartesProtocol.ts
@@ -85,12 +85,13 @@ export class Protocol {
 		const isIn29 = booleanContains(polygon29, tilePolygon)
 		//		console.log('boupmoi is in', isInHexagon, hexagonePlusPolygon, tilePolygon)
 
-		const serverDevMode = process.env.NEXT_PUBLIC_LOCAL_GTFS_SERVER === 'true'
+		const iterateOnLocalTiles =
+			process.env.NEXT_PUBLIC_ITERATE_ON_LOCAL_TILES === 'true'
 
 		const pmtilesUrl =
-			serverDevMode && isIn35
+			iterateOnLocalTiles && isIn35
 				? pmtilesUrl3
-				: serverDevMode && isIn29
+				: iterateOnLocalTiles && isIn29
 				? pmtilesUrl4
 				: isInHexagon
 				? pmtilesUrl1


### PR DESCRIPTION
- [x] prise en compte des GTFS de type calendar, la base, je l'avais laissé de côté trop longtemps car la Bretagne utilisait calendar_dates plutôt
- [ ] quand ambigüité sur les arrêts de bus, les afficher tous

Pas simple : il faut gérer les pb de localisation OSM. Quand les données GTFS existent, il faut s'y référer en priorité. 

http://localhost:8080/?style=france&allez=Ragon|n719548249|-1.5426|47.1652#19/47.1653/-1.5427682

Ici les deux arrêts de bus OSM des deux sens sont plus proches de l'un des arrêts réels que de l'autre. Sur la vue purement GTFS du mode transport, on gère le truc correctement. 

OK, c'était un problème de tri des résultats de geoStops ! Cela dit, il faudrait quand même pouvoir afficher les autres arrêts. 

~Ça m'a permis de découvrir un nouveau problème : https://github.com/cartesapp/serveur/issues/55~

- [x] Problème de sens des bus, on inverse les directions là sur l'arrêt Ragon, à cause d'un code spécifique à Rennes/Bretagne 

Solution : utiliser headsign de trip ? C'est peut-être le truc qui nous manquait ! Plutôt que la route_long_name absolument pas fiable car pas faite pour ça. Ah, pas dispo pour fr-bre, je comprends mon choix. Mais à privilégier pour les autres réseaux. Putain ils font chier avec leur implé partielle de GTFS :angry: 



