### PR TITLE
Ajout des tuiles satellite IGN

### DIFF
--- a/app/styles/satellite-ign.ts
+++ b/app/styles/satellite-ign.ts
@@ -1,0 +1,35 @@
+export default function natureStyle() {
+	return {
+		version: 8,
+		id: 'satellite',
+		name: 'Satellite',
+		sources: {
+			'terrain-rgb': {
+				url: `https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json?key=${key}`,
+				type: 'raster-dem',
+			},
+			'satellite-tiles': {
+				type: 'raster',
+				tiles: [
+					'https://data.geopf.fr/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/jpeg&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
+				],
+				tileSize: 256,
+				attribution: 'IGN-F/Geoportail',
+			},
+		},
+		layers: [
+			{
+				id: 'satellite-layer',
+				type: 'raster',
+				source: 'satellite-tiles',
+				paint: {},
+			},
+		],
+		bearing: 0,
+		pitch: 0,
+		center: [0, 0],
+		zoom: 1,
+		minZoom: 0,
+		maxZoom: 18,
+	}
+}

--- a/app/styles/styles.ts
+++ b/app/styles/styles.ts
@@ -5,6 +5,7 @@ import franceStyle from './france'
 import natureStyle from './nature'
 import railStyle from './railStyle'
 import satellite from './satellite'
+import satelliteIgn from './satellite-ign'
 import testStreetComplete from './test-street-complete'
 import voyageStyle from './voyage'
 
@@ -38,9 +39,15 @@ export const styles = {
 		description: `C'est l'ancienne version du style principal, qui reste meilleur pour un certain nombre d'aspects : noms des lieux étrangers en français, moins de bugs sur les côtes.`,
 		emoji: '🗺️',
 	},
+	'satellite-ign': {
+		url: satelliteIgn(),
+		name: 'Satellite France',
+		emoji: '🛰️',
+		hasTerrain: true,
+	},
 	satellite: {
 		url: satellite(key),
-		name: 'Satellite',
+		name: 'Satellite Monde',
 		emoji: '🛰️',
 		hasTerrain: true,
 	},


### PR DESCRIPTION
Très bonnes pour la France et peut-être l'Europe, mais nulles pour le reste du monde. Donc à compléter avec MapTiler. À hybrider ?

- [ ] pour l'europe c'est haute def ? 
- [ ] intégrer *notre* terrain pour réduire les coûts maptiler, sur satellite IGN *et* sur le reste
- [ ] afficher la date ? comment ? 