### PR TITLE
feat: Add Marker On Opening Hours

### DIFF
--- a/app/osm/OpeningHours.tsx
+++ b/app/osm/OpeningHours.tsx
@@ -89,7 +89,6 @@ export const OpeningHours = ({ opening_hours }) => {
 		<Wrapper>
 			<details open={false}>
 				<summary title="Voir tous les horaires">
-					<OpenIndicator isOpen={isOpen === 'error' ? false : isOpen} />{' '}
 					{isOpen === 'error' && <span>Problème dans les horaires</span>}
 					{nextChange === 'error' ? null : !nextChange ? (
 						<span>Ouvert 24/24 7j/7</span>
@@ -98,6 +97,7 @@ export const OpeningHours = ({ opening_hours }) => {
 							{isOpen ? 'Ouvert' : 'Fermé'} jusqu'à {formatDate(nextChange)}
 						</span>
 					)}
+					<OpenIndicator isOpen={isOpen === 'error' ? false : isOpen} />{' '}
 				</summary>
 
 				{intervals != null && !ohPerDay.error ? (
@@ -139,6 +139,14 @@ const Wrapper = styled.div`
 		list-style-type: none;
 		display: flex;
 		align-items: center;
+	}
+	summary::before {
+		content: '▶'; 
+		margin-right: 8px;
+		transition: transform 0.3s;
+	}
+	details[open] summary::before {
+		transform: rotate(90deg);
 	}
 	ul {
 		padding-left: 2rem;


### PR DESCRIPTION
## Avant : 
<img width="450" alt="image" src="https://github.com/user-attachments/assets/d07700a1-b1c3-47d6-8df7-f1ed15c3683e" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/2e028f54-ad8e-4a34-91b9-d74c34d0c29b" />

L'utilisateur ne sait pas qu'il peut cliquer.


## Après : 
<img width="450" alt="image" src="https://github.com/user-attachments/assets/39c00478-dff4-4009-bff0-65a5afa3d72b" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/ec49a3aa-e604-4a73-a298-d5792fa85e09" />

J'ai déplacé à droite l'icone d'ouverture pour une meilleure lisibilité avec le symbole de marker.