### PR TITLE
Add monochrom icon

### DIFF
--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -21,6 +21,12 @@ export default function manifest(): MetadataRoute.Manifest {
 				purpose: 'any',
 			},
 			{
+				src: 'https://cartes.app/logo-mono.svg',
+				sizes: '48x48 72x72 96x96 128x128 256x256',
+				type: 'image/svg+xml',
+				purpose: 'monochrome',
+			},
+			{
 				src: 'https://cartes.app/icon-192.png',
 				sizes: '192x192',
 				type: 'image/png',

--- a/public/logo-mono.svg
+++ b/public/logo-mono.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="210mm" height="210mm" viewBox="0 0 210 210" version="1.1" id="svg1" inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)" sodipodi:docname="voyage.svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview id="namedview1" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:showpageshadow="2" inkscape:pageopacity="0.0" inkscape:pagecheckerboard="0" inkscape:deskcolor="#d1d1d1" inkscape:document-units="mm" inkscape:zoom="0.51852296" inkscape:cx="389.56809" inkscape:cy="320.14011" inkscape:window-width="1920" inkscape:window-height="1055" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="1" inkscape:current-layer="layer1" showgrid="false"/>
+  <defs id="defs1"/>
+  <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1">
+    <rect style="fill:#000000;fill-opacity:0.2;fill-rule:evenodd;stroke-width:0.138033" id="rect2" width="203.96568" height="203.96568" x="3.5503716" y="3.1170206" ry="56.103344"/>
+    <circle style="fill:#000000;fill-opacity:0.5;fill-rule:evenodd;stroke-width:0.138033" id="path2-6" cx="103.83656" cy="104.80544" r="68.791901"/>
+    <circle style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke-width:0.0683626" id="path2-3-2" cx="103.75215" cy="105.48904" r="34.070286"/>
+  </g>
+</svg>


### PR DESCRIPTION
This should add themed icons to Android.

I have not tested, I hope it works as expected with the other icon's purpose = any

https://w3c.github.io/manifest/#dfn-monochrome