### PR TITLE
Afficher la date du dernier changeset sur la fiche d'un lieu

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_GTFS_SERVER_URL = "https://serveur.cartes.app/gtfs"
 NEXT_PUBLIC_PMTILES_SERVER_URL = "https://serveur.cartes.app/pmtiles"
 NEXT_PUBLIC_MOTIS_SERVER_URL = "https://serveur.cartes.app/motis2"
-NEXT_PUBLIC_PHOTON_SERVER_URL = "https://serveur.cartes.app/photon"
+NEXT_PUBLIC_PHOTON_SERVER_URL = "https://photon.komoot.io"
 NEXT_PUBLIC_BASE_DOMAIN = "cartes.app"

--- a/app/OsmFeature.tsx
+++ b/app/OsmFeature.tsx
@@ -28,7 +28,7 @@ import CityData from '@/components/osm/CityData'
 export default function OsmFeature(props) {
 	const { data, transportStopData, photonFeature, similarNodes } = props
 	if (!data.tags) return null
-	const { tags } = data
+	const { tags, meta } = data
 
 	const id = data.id
 	const featureType = data.type || data.featureType
@@ -99,6 +99,15 @@ export default function OsmFeature(props) {
 	const name = getName(tags)
 	const nameKeys = getNameKeys(tags)
 
+	// Formatage en français de la date du dernier changeset
+	const changesetDate = new Date(meta.timestamp)
+	const options = {
+	day: 'numeric',
+	month: 'long',
+	year: 'numeric'
+	};
+	meta.frenchDate = changesetDate.toLocaleDateString('fr-FR', options);
+
 	const filteredRest = omit([addressKeys, transportKeys, nameKeys].flat(), rest)
 
 	const [keyValueTags, soloTags] = processTags(filteredRest)
@@ -157,6 +166,12 @@ export default function OsmFeature(props) {
 				</div>
 			)}
 			<Address tags={tags} photonFeature={photonFeature} />
+			{ /* display intel about the last changeset of this element */ }
+			{meta && <small>mis à jour le {meta.frenchDate} par <a
+				href={`https://www.openstreetmap.org/user/${meta.user}`}
+				target="_blank"
+				title={`Lien vers la fiche OSM de l'utilisateur ${meta.user}`}
+			>{meta.user}</a></small>}
 			{tags.uic_ref && (
 				<GareInfo
 					{...{

--- a/app/OsmFeature.tsx
+++ b/app/OsmFeature.tsx
@@ -28,7 +28,7 @@ import CityData from '@/components/osm/CityData'
 export default function OsmFeature(props) {
 	const { data, transportStopData, photonFeature, similarNodes } = props
 	if (!data.tags) return null
-	const { tags, meta } = data
+	const { tags } = data
 
 	const id = data.id
 	const featureType = data.type || data.featureType
@@ -99,15 +99,6 @@ export default function OsmFeature(props) {
 	const name = getName(tags)
 	const nameKeys = getNameKeys(tags)
 
-	// Formatage en français de la date du dernier changeset
-	const changesetDate = new Date(meta.timestamp)
-	const options = {
-	day: 'numeric',
-	month: 'long',
-	year: 'numeric'
-	};
-	meta.frenchDate = changesetDate.toLocaleDateString('fr-FR', options);
-
 	const filteredRest = omit([addressKeys, transportKeys, nameKeys].flat(), rest)
 
 	const [keyValueTags, soloTags] = processTags(filteredRest)
@@ -166,12 +157,7 @@ export default function OsmFeature(props) {
 				</div>
 			)}
 			<Address tags={tags} photonFeature={photonFeature} />
-			{ /* display intel about the last changeset of this element */ }
-			{meta && <small>mis à jour le {meta.frenchDate} par <a
-				href={`https://www.openstreetmap.org/user/${meta.user}`}
-				target="_blank"
-				title={`Lien vers la fiche OSM de l'utilisateur ${meta.user}`}
-			>{meta.user}</a></small>}
+			{/* display intel about the last changeset of this element */}
 			{tags.uic_ref && (
 				<GareInfo
 					{...{

--- a/app/osmRequest.ts
+++ b/app/osmRequest.ts
@@ -57,7 +57,7 @@ export const osmElementRequest = async (featureType, id) => {
 	*/
 
 	// build the query
-	const query = buildOverpassElementQuery(featureType, id, false)
+	const query = buildOverpassElementQuery(featureType, id, true)
 
 	try {
 		// fetch the query
@@ -215,8 +215,13 @@ export const extendOverpassElement = (element) => {
 	return {
 		type: element.type,
 		id: element.id,
-		osmCode: encodePlace(element.type, element.id), //useless here, should be calculated when needed
+		osmCode: encodePlace(element.type, element.id), //useless here ? should be calculated when needed ?
 		tags: element.tags || {},
+		meta: {
+			timestamp: element.timestamp,
+			user: element.user,
+			uid: element.uid,
+		},
 		//bounds: element.bounds,
 		geojson,
 		center,

--- a/components/OsmLinks.tsx
+++ b/components/OsmLinks.tsx
@@ -5,35 +5,74 @@ import Image from 'next/image'
 
 export default function OsmLinks({ data }) {
 	const [featureType, id] = decodePlace(data.osmCode)
+	const { meta } = data
+	// Formatage en français de la date du dernier changeset
+	const changesetDate = new Date(meta.timestamp)
+	const options = {
+		day: 'numeric',
+		month: 'long',
+		year: 'numeric',
+	}
+	const frenchDate = changesetDate.toLocaleDateString('fr-FR', options)
+
 	return (
-		<Wrapper>
-			<Image
-				src={osmLogo}
-				width="30"
-				height="30"
-				alt="Logo d'OpenStreetMap"
-			/>
-			<a
-				href={`https://openstreetmap.org/${featureType}/${id}`}
-				target="_blank"
-				title="Voir la fiche OpenStreetMap de ce lieu"
-			>Voir</a>
-			&nbsp;ou&nbsp;
-			<a
-				href={`https://openstreetmap.org/edit?${featureType}=${id}`}
-				target="_blank"
-				title="Ajouter des informations à ce lieu sur OpenStreetMap"
-			>compléter</a>
-			&nbsp;ce lieu sur OpenStreetMap
-		</Wrapper>
+		<Section>
+			<div>
+				{meta && (
+					<small>
+						mis à jour le {frenchDate} par{' '}
+						<a
+							href={`https://www.openstreetmap.org/user/${meta.user}`}
+							target="_blank"
+							title={`Lien vers la fiche OSM de l'utilisateur ${meta.user}`}
+						>
+							{meta.user}
+						</a>
+					</small>
+				)}
+			</div>
+			<OsmLinksWrapper>
+				<Image
+					src={osmLogo}
+					width="30"
+					height="30"
+					alt="Logo d'OpenStreetMap"
+				/>
+				<a
+					href={`https://openstreetmap.org/${featureType}/${id}`}
+					target="_blank"
+					title="Voir la fiche OpenStreetMap de ce lieu"
+				>
+					Voir
+				</a>
+				&nbsp;ou&nbsp;
+				<a
+					href={`https://openstreetmap.org/edit?${featureType}=${id}`}
+					target="_blank"
+					title="Ajouter des informations à ce lieu sur OpenStreetMap"
+				>
+					compléter
+				</a>
+				&nbsp;ce lieu sur OpenStreetMap
+			</OsmLinksWrapper>
+		</Section>
 	)
 }
 
-const Wrapper = styled.section`
-	display: flex;
+const Section = styled.section`
 	margin-top: 2rem;
 	margin-bottom: 0.2rem;
-	justify-content: center;
+	> div {
+		margin-bottom: 0.3rem;
+		> small {
+			margin-right: 0.4rem;
+			color: var(--darkerColor);
+			text-align: right;
+		}
+	}
+`
+const OsmLinksWrapper = styled.section`
+	display: flex;
 	align-items: center;
 	img {
 		width: 1.6rem;

--- a/components/OsmLinks.tsx
+++ b/components/OsmLinks.tsx
@@ -2,6 +2,7 @@ import { decodePlace } from '@/app/utils'
 import osmLogo from '@/public/openstreetmap.svg'
 import { styled } from 'next-yak'
 import Image from 'next/image'
+import crayonIcon from '@/public/crayon.svg'
 
 export default function OsmLinks({ data }) {
 	const [featureType, id] = decodePlace(data.osmCode)
@@ -20,6 +21,7 @@ export default function OsmLinks({ data }) {
 			<div>
 				{meta && (
 					<small>
+						<Image src={crayonIcon} width="10" height="10" alt="Icône crayon" />
 						mis à jour le {frenchDate} par{' '}
 						<a
 							href={`https://www.openstreetmap.org/user/${meta.user}`}
@@ -68,6 +70,12 @@ const Section = styled.section`
 			margin-right: 0.4rem;
 			color: var(--darkerColor);
 			text-align: right;
+		}
+		img {
+			width: 1rem;
+			vertical-align: sub;
+			height: auto;
+			margin-right: 0.2rem;
 		}
 	}
 `

--- a/components/OsmLinks.tsx
+++ b/components/OsmLinks.tsx
@@ -66,10 +66,10 @@ const Section = styled.section`
 	margin-bottom: 0.2rem;
 	> div {
 		margin-bottom: 0.3rem;
+		text-align: right;
 		> small {
 			margin-right: 0.4rem;
 			color: var(--darkerColor);
-			text-align: right;
 		}
 		img {
 			width: 1rem;

--- a/components/OsmLinks.tsx
+++ b/components/OsmLinks.tsx
@@ -7,25 +7,24 @@ export default function OsmLinks({ data }) {
 	const [featureType, id] = decodePlace(data.osmCode)
 	return (
 		<Wrapper>
+			<Image
+				src={osmLogo}
+				width="30"
+				height="30"
+				alt="Logo d'OpenStreetMap"
+			/>
 			<a
 				href={`https://openstreetmap.org/${featureType}/${id}`}
 				target="_blank"
 				title="Voir la fiche OpenStreetMap de ce lieu"
-			>
-				<Image
-					src={osmLogo}
-					width="30"
-					height="30"
-					alt="Logo d'OpenStreetMap"
-				/>
-			</a>
+			>Voir</a>
+			&nbsp;ou&nbsp;
 			<a
 				href={`https://openstreetmap.org/edit?${featureType}=${id}`}
 				target="_blank"
 				title="Ajouter des informations à ce lieu sur OpenStreetMap"
-			>
-				Compléter ce lieu sur OpenStreetMap
-			</a>
+			>compléter</a>
+			&nbsp;ce lieu sur OpenStreetMap
 		</Wrapper>
 	)
 }

--- a/components/news/news.yaml
+++ b/components/news/news.yaml
@@ -1,3 +1,13 @@
+- title: 🚍️ Nouvelle version du calculateur d'itinéraires
+  date: 2025-06-09
+  description: |
+
+    Deux nouveautés : 
+      - le calculateur que nous utilisons, Motis, passe de la v1 à la v2
+      - l'interface est mise à jour avec un tas de nouveautés, dont des trajets plus intelligents dans les zones peu denses... c'est à dire l'essentiel de la France ! 
+
+    Toutes les nouveautés sont [expliquées et illustrées ici](https://bsky.app/profile/cartes.app/post/3lr6n2fah222i).
+
 - title: 📐 Affichage des rivières et des rues
   date: 2025-06-05
   description: |


### PR DESCRIPTION
Comme discuté lorsqu'on est passé à overpass, je propose d'ajouter sur la fiche lieu une petite phrase indiquant la date du dernier changeset, et le nom de l'utilisateur l'ayant réalisée (pour le remercier et mettre en valeur la communauté).
@laem je l'ai positionnée après l'adresse, mais je n'étais pas très inspiré, n'hésite pas à déplacer si tu préfères que ça apparaisse ailleurs.

![image](https://github.com/user-attachments/assets/f92abbc4-9810-47e3-894e-ded58b79098b)

J'en profite pour changer le bandeau du bas avec les liens vers OSM car moi même je n'avais pas vu que l'image était un lien vers la fiche OSM.

![image](https://github.com/user-attachments/assets/6caf7994-023e-4fee-8b55-b3efb8c704d1)