### PR TITLE
Améliorer la recherche de la catégorie d'un élément OSM via ses tags

### DIFF
--- a/app/moreCategories.yaml
+++ b/app/moreCategories.yaml
@@ -877,7 +877,7 @@
   group: Poubelles
   dictionary:
     - bouteille
-  query: '[amenity=recycling]["recycling:glass_bottles"=yes]'
+  query: '["recycling:glass_bottles"=yes]'
   icon: recycling
 
 - name: (conteneurs à )vêtement(s) # no s to avoid key collision with the shop
@@ -885,7 +885,7 @@
   dictionary:
     - coton
     - tissus
-  query: '[amenity=recycling]["recycling:clothes"=yes]'
+  query: '["recycling:clothes"=yes]'
   icon: recycling
 
 - name: (conteneurs à )emballages
@@ -910,7 +910,7 @@
   dictionary:
     - piles
     - batterie
-  query: '[amenity=recycling]["recycling:batteries"=yes]'
+  query: '["recycling:batteries"=yes]'
   icon: recycling
 
 #######################


### PR DESCRIPTION
Cette PR améliore la recherche d'1 catégorie correspondant aux tags d'un élément OSM.

L'idée est de ne pas juste tester si il y a des matchs entre les tags et la query (en renvoyant le premier match comme avant), mais de compter le nombre de match. Ca donne un score, qui permet d'extraire la catégorie avec le plus de matchs. Ca permet donc d'être plus précis en trouvant la catégorie qui correspond le mieux aux tags.

Pour que le score soit comparable, il faut que les requêtes overpass de catégories proches soient avec une syntaxe proche. Par exemple, j'ai corrigé les conteneurs de recyclage, car certains avaient `[amenity=recycling]["recycling:xxx"=yes]` alors que d'autres avaient `["recycling:xxx"=yes]`, ce qui faussait le calcul.

Mais il y a encore des cas avec le même score. Par exemple `contient amenity et parking` match dans `amenity=parking` et dans `amenity=bicycle_parking`. On est donc obligés de gérer quelques cas manuellement.

:warning: il y a des effets dont je ne sais pas dire si ils sont souhaitables ou non. Par exemple, la fiche d'une crêperie n'affiche plus que les crêperies proches, alors qu'avant elle affichait tous les restaurants proches. Tout dépend si l'utilisateur cherche spécifiquement une crêperie ou juste un restaurant. Mais bon, si il cherche un restaurant, il a toujours la possibilité d'afficher la catégorie `tous les restaurants`. Donc finalement ça me parait bien de n'afficher que les crêperies proches.

fixes #952 