### PR TITLE
fix bug #977 geometry not displayed after click on photon result

### DIFF
--- a/app/effects/useDrawSearchResults.ts
+++ b/app/effects/useDrawSearchResults.ts
@@ -31,6 +31,7 @@ export default function useDrawSearchResults(map, state, setOsmFeature) {
 
 const category = {
 	name: 'search',
+	key: 'search-result',
 	icon: 'search-result',
 	iconSize: 22,
 }


### PR DESCRIPTION
@laem c'est bon j'ai trouvé comment résoudre le bug. Pas grand chose à voir avec les useEffect, je n'avais juste pas pensé que :
- le format d'une `category` est mimé pour afficher les résultats de la recherche photon
- cette catégorie là ne passe pas par le script qui lit `moreCategories.yaml`,
- donc sa `key` n'est pas créée automatiquement,
- il faut la définir manuellement

ça faisait planter (sans le dire) le calcul de `const baseId = 'features-${category.key}-'` qui donnait toujours `undefined`.