### PR TITLE
Hide private POIs in categories car parking and playground

### DIFF
--- a/app/moreCategories.yaml
+++ b/app/moreCategories.yaml
@@ -1327,7 +1327,7 @@
   group: Déplacements
   dictionary:
     - stationnement
-  query: '[amenity=parking]'
+  query: '[amenity=parking][access!~"private|no"]'
   icon: parking
 
 - name: Aire(s) de covoiturage

--- a/app/moreCategories.yaml
+++ b/app/moreCategories.yaml
@@ -1027,8 +1027,8 @@
     - manège
     - aire de jeu
   query:
-    - '[leisure=playground]'
-    - '[landuse=recreation_ground]'
+    - '[leisure=playground][access!~"private|no"]'
+    - '[landuse=recreation_ground][access!~"private|no"]'
     - '[attraction=carousel]'
   icon: playground
 


### PR DESCRIPTION
Une mini PR en cohérence avec cartesapp/serveur#63 et en lien avec #860 pour masquer les éléments privés dans les 2 catégories :
- parking voiture
- jeux pour enfants

J'ai parcouru tout `moreCategories.yaml` et je n'ai pas vu d'autre catégorie qui pourrait avoir beaucoup d'éléments privés à masquer. J'ai hésité sur les gymnases et les terrains de sport pour éliminer ceux dans les établissements scolaires, et puis non je les ai laissés.

| avant | après |
|----|----|
| ![Image](https://github.com/user-attachments/assets/541d8ca9-c7f4-4b47-b0c9-762bff82c55a) | ![Image](https://github.com/user-attachments/assets/f7b44af4-3a40-47fe-9413-8fbdf76f5416) |